### PR TITLE
Continue to restructure types generation

### DIFF
--- a/internal/generate/test_utils/oneof-test
+++ b/internal/generate/test_utils/oneof-test
@@ -1,0 +1,25 @@
+// ImageSourceUrl is the type definition for a ImageSourceUrl.
+type ImageSourceUrl struct {
+	Type ImageSourceType `json:"type,omitempty" yaml:"type,omitempty"`
+	Url string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+// ImageSourceType is the type definition for a ImageSourceType.
+type ImageSourceType string
+const (
+// ImageSourceTypeUrl represents the ImageSourceType `"url"`.
+	ImageSourceTypeUrl ImageSourceType = "url"
+)
+
+
+// ImageSourceSnapshot is the type definition for a ImageSourceSnapshot.
+type ImageSourceSnapshot struct {
+	Id string `json:"id,omitempty" yaml:"id,omitempty"`
+	Type ImageSourceType `json:"type,omitempty" yaml:"type,omitempty"`
+}
+const (
+// ImageSourceTypeSnapshot represents the ImageSourceType `"snapshot"`.
+	ImageSourceTypeSnapshot ImageSourceType = "snapshot"
+)
+
+
+// ImageSource is the source of the underlying image.

--- a/internal/generate/types_test.go
+++ b/internal/generate/types_test.go
@@ -127,9 +127,8 @@ func Test_createTypeObject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := createTypeObject(tt.args.s, tt.args.name, tt.args.typeName); got != tt.want {
-				assert.Equal(t, tt.want, got)
-			}
+			got := createTypeObject(tt.args.s, tt.args.name, tt.args.typeName)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/generate/types_test.go
+++ b/internal/generate/types_test.go
@@ -132,3 +132,34 @@ func Test_createTypeObject(t *testing.T) {
 		})
 	}
 }
+
+func Test_createStringEnum(t *testing.T) {
+	typesSpec := &openapi3.Schema{Enum: []interface{}{"admin", "collaborator", "viewer"}}
+	enums := map[string][]string{}
+	type args struct {
+		s           *openapi3.Schema
+		stringEnums map[string][]string
+		name        string
+		typeName    string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  string
+		want1 map[string][]string
+	}{
+		{
+			name:  "success",
+			args:  args{typesSpec, enums, "FleetRole", "FleetRole"},
+			want:  "// FleetRole is the type definition for a FleetRole.\ntype FleetRole string\nconst (\n// FleetRoleAdmin represents the FleetRole `\"admin\"`.\n\tFleetRoleAdmin FleetRole = \"admin\"\n// FleetRoleCollaborator represents the FleetRole `\"collaborator\"`.\n\tFleetRoleCollaborator FleetRole = \"collaborator\"\n// FleetRoleViewer represents the FleetRole `\"viewer\"`.\n\tFleetRoleViewer FleetRole = \"viewer\"\n)\n",
+			want1: map[string][]string{"FleetRole": {"admin", "collaborator", "viewer"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := createStringEnum(tt.args.s, tt.args.stringEnums, tt.args.name, tt.args.typeName)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want1, got1)
+		})
+	}
+}


### PR DESCRIPTION
Extracts code into smaller functions and removes the amount of places where code is printed out