### PR TITLE
Populate `TypeTemplate` structs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/oxidecomputer/oxide.go
 go 1.17
 
 require (
+	github.com/davecgh/go-spew v1.1.1
 	github.com/getkin/kin-openapi v0.99.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/stretchr/testify v1.8.0
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.5 // indirect
 	github.com/invopop/yaml v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/oxidecomputer/oxide.go
 go 1.17
 
 require (
-	github.com/getkin/kin-openapi v0.98.0
+	github.com/getkin/kin-openapi v0.99.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/getkin/kin-openapi v0.98.0 h1:lIACvCG9cxmFsEywz+LCoVhcZHFLUy+Nv5QSkb43eAE=
-github.com/getkin/kin-openapi v0.98.0/go.mod h1:w4lRPHiyOdwGbOkLIyk+P0qCwlu7TXPCHD/64nSXzgE=
+github.com/getkin/kin-openapi v0.99.0 h1:PWi80eCqneZCXI06qvaab7wmO1SZXf0fTP87B1JDwMA=
+github.com/getkin/kin-openapi v0.99.0/go.mod h1:w4lRPHiyOdwGbOkLIyk+P0qCwlu7TXPCHD/64nSXzgE=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=

--- a/internal/generate/responses.go
+++ b/internal/generate/responses.go
@@ -66,7 +66,9 @@ func writeResponseType(f *os.File, name string, r *openapi3.Response) {
 			continue
 		}
 
+		// TODO: Ignore the TypeTemplate for now
 		// TODO: bubble up printing like types
-		fmt.Fprint(f, writeSchemaType(name, s.Value, ""))
+		resposeType, _ := writeSchemaType(name, s.Value, "")
+		fmt.Fprint(f, resposeType)
 	}
 }


### PR DESCRIPTION
Start constructing `[]TypeTemplate` to use instead of writing to file from several places, or saving the entire file in a string variable.

Done:
- [X] objects
- [X] strings
- [X] string enums
- [X] integer
- [X] number
- [X] boolean