### PR TITLE
Populate TypeTemplates with OneOf

### DIFF
--- a/internal/generate/types_test.go
+++ b/internal/generate/types_test.go
@@ -224,21 +224,56 @@ func Test_createOneOf(t *testing.T) {
 		typeName string
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name  string
+		args  args
+		want  string
+		want2 []TypeTemplate
 	}{
 		{
 			name: "success",
 			args: args{typeSpec, "ImageSource", "ImageSource"},
 			want: "// ImageSourceUrl is the type definition for a ImageSourceUrl.\ntype ImageSourceUrl struct {\n\tType ImageSourceType `json:\"type,omitempty\" yaml:\"type,omitempty\"`\n\tUrl string `json:\"url,omitempty\" yaml:\"url,omitempty\"`\n}\n// ImageSourceType is the type definition for a ImageSourceType.\ntype ImageSourceType string\nconst (\n// ImageSourceTypeUrl represents the ImageSourceType `\"url\"`.\n\tImageSourceTypeUrl ImageSourceType = \"url\"\n)\n\n\n// ImageSourceSnapshot is the type definition for a ImageSourceSnapshot.\ntype ImageSourceSnapshot struct {\n\tId string `json:\"id,omitempty\" yaml:\"id,omitempty\"`\n\tType ImageSourceType `json:\"type,omitempty\" yaml:\"type,omitempty\"`\n}\nconst (\n// ImageSourceTypeSnapshot represents the ImageSourceType `\"snapshot\"`.\n\tImageSourceTypeSnapshot ImageSourceType = \"snapshot\"\n)\n\n\n// ImageSource is the source of the underlying image.\ntype ImageSource struct {\n\tType string `json:\"type,omitempty\" yaml:\"type,omitempty\"`\n\tUrl string `json:\"url,omitempty\" yaml:\"url,omitempty\"`\n\tId string `json:\"id,omitempty\" yaml:\"id,omitempty\"`\n}\n",
+			want2: []TypeTemplate{
+				{
+					Description: "", Name: "", Type: ""},
+				{
+					Description: "// ImageSourceUrl is the type definition for a ImageSourceUrl.", Name: "ImageSourceUrl", Type: "struct", Fields: []TypeFields{
+						{
+							Description: "", Name: "Type", Type: "ImageSourceType", SerializationInfo: "`json:\"type,omitempty\" yaml:\"type,omitempty\"`"},
+						{
+							Description: "", Name: "Url", Type: "string", SerializationInfo: "`json:\"url,omitempty\" yaml:\"url,omitempty\"`",
+						},
+					},
+				},
+				{
+					Description: "", Name: "", Type: "",
+				},
+				{
+					Description: "// ImageSourceSnapshot is the type definition for a ImageSourceSnapshot.", Name: "ImageSourceSnapshot", Type: "struct", Fields: []TypeFields{
+						{
+							Description: "", Name: "Id", Type: "string", SerializationInfo: "`json:\"id,omitempty\" yaml:\"id,omitempty\"`"},
+						{
+							Description: "", Name: "Type", Type: "ImageSourceType", SerializationInfo: "`json:\"type,omitempty\" yaml:\"type,omitempty\"`"},
+					},
+				},
+				{
+					Description: "// ImageSource is the source of the underlying image.", Name: "ImageSource", Type: "struct", Fields: []TypeFields{
+						{
+							Description: "", Name: "Type", Type: "string", SerializationInfo: "`json:\"type,omitempty\" yaml:\"type,omitempty\"`"},
+						{
+							Description: "", Name: "Url", Type: "string", SerializationInfo: "`json:\"url,omitempty\" yaml:\"url,omitempty\"`"},
+						{
+							Description: "", Name: "Id", Type: "string", SerializationInfo: "`json:\"id,omitempty\" yaml:\"id,omitempty\"`"},
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := createOneOf(tt.args.s, tt.args.name, tt.args.typeName)
+			got, typeTpls := createOneOf(tt.args.s, tt.args.name, tt.args.typeName)
 			assert.Equal(t, tt.want, got)
-
+			assert.Equal(t, tt.want2, typeTpls)
 		})
 	}
 }


### PR DESCRIPTION
Construct []TypeTemplate to use instead of writing to file from several places, or saving the entire file in a string variable for OneOf.