### PR TITLE
Populate template structs for enums

### DIFF
--- a/internal/generate/responses.go
+++ b/internal/generate/responses.go
@@ -68,7 +68,7 @@ func writeResponseType(f *os.File, name string, r *openapi3.Response) {
 
 		// TODO: Ignore the TypeTemplate for now
 		// TODO: bubble up printing like types
-		resposeType, _ := writeSchemaType(name, s.Value, "")
+		resposeType, _, _ := writeSchemaType(name, s.Value, "")
 		fmt.Fprint(f, resposeType)
 	}
 }

--- a/internal/generate/types_test.go
+++ b/internal/generate/types_test.go
@@ -166,19 +166,29 @@ func Test_createStringEnum(t *testing.T) {
 		args  args
 		want  string
 		want1 map[string][]string
+		want2 []TypeTemplate
+		want3 []EnumTemplate
 	}{
 		{
 			name:  "success",
 			args:  args{typesSpec, enums, "FleetRole", "FleetRole"},
 			want:  "// FleetRole is the type definition for a FleetRole.\ntype FleetRole string\nconst (\n// FleetRoleAdmin represents the FleetRole `\"admin\"`.\n\tFleetRoleAdmin FleetRole = \"admin\"\n// FleetRoleCollaborator represents the FleetRole `\"collaborator\"`.\n\tFleetRoleCollaborator FleetRole = \"collaborator\"\n// FleetRoleViewer represents the FleetRole `\"viewer\"`.\n\tFleetRoleViewer FleetRole = \"viewer\"\n)\n",
 			want1: map[string][]string{"FleetRole": {"admin", "collaborator", "viewer"}},
+			want2: []TypeTemplate{{Description: "// FleetRole is the type definition for a FleetRole.", Name: "FleetRole", Type: "string"}},
+			want3: []EnumTemplate{
+				{Description: "// FleetRoleAdmin represents the FleetRole `\"admin\"`.", Name: "FleetRoleAdmin", ValueType: "const", Value: "FleetRole = \"admin\""},
+				{Description: "// FleetRoleCollaborator represents the FleetRole `\"collaborator\"`.", Name: "FleetRoleCollaborator", ValueType: "const", Value: "FleetRole = \"collaborator\""},
+				{Description: "// FleetRoleViewer represents the FleetRole `\"viewer\"`.", Name: "FleetRoleViewer", ValueType: "const", Value: "FleetRole = \"viewer\""},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := createStringEnum(tt.args.s, tt.args.stringEnums, tt.args.name, tt.args.typeName)
+			got, got1, got2, got3 := createStringEnum(tt.args.s, tt.args.stringEnums, tt.args.name, tt.args.typeName)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.want1, got1)
+			assert.Equal(t, tt.want2, got2)
+			assert.Equal(t, tt.want3, got3)
 		})
 	}
 }
@@ -228,6 +238,7 @@ func Test_createOneOf(t *testing.T) {
 		args  args
 		want  string
 		want2 []TypeTemplate
+		want3 []EnumTemplate
 	}{
 		{
 			name: "success",
@@ -235,11 +246,16 @@ func Test_createOneOf(t *testing.T) {
 			want: "// ImageSourceUrl is the type definition for a ImageSourceUrl.\ntype ImageSourceUrl struct {\n\tType ImageSourceType `json:\"type,omitempty\" yaml:\"type,omitempty\"`\n\tUrl string `json:\"url,omitempty\" yaml:\"url,omitempty\"`\n}\n// ImageSourceType is the type definition for a ImageSourceType.\ntype ImageSourceType string\nconst (\n// ImageSourceTypeUrl represents the ImageSourceType `\"url\"`.\n\tImageSourceTypeUrl ImageSourceType = \"url\"\n)\n\n\n// ImageSourceSnapshot is the type definition for a ImageSourceSnapshot.\ntype ImageSourceSnapshot struct {\n\tId string `json:\"id,omitempty\" yaml:\"id,omitempty\"`\n\tType ImageSourceType `json:\"type,omitempty\" yaml:\"type,omitempty\"`\n}\nconst (\n// ImageSourceTypeSnapshot represents the ImageSourceType `\"snapshot\"`.\n\tImageSourceTypeSnapshot ImageSourceType = \"snapshot\"\n)\n\n\n// ImageSource is the source of the underlying image.\ntype ImageSource struct {\n\tType string `json:\"type,omitempty\" yaml:\"type,omitempty\"`\n\tUrl string `json:\"url,omitempty\" yaml:\"url,omitempty\"`\n\tId string `json:\"id,omitempty\" yaml:\"id,omitempty\"`\n}\n",
 			want2: []TypeTemplate{
 				{
-					Description: "", Name: "", Type: ""},
+					Description: "// ImageSourceType is the type definition for a ImageSourceType.", Name: "ImageSourceType", Type: "string",
+				},
+				{
+					Description: "", Name: "", Type: "",
+				},
 				{
 					Description: "// ImageSourceUrl is the type definition for a ImageSourceUrl.", Name: "ImageSourceUrl", Type: "struct", Fields: []TypeFields{
 						{
-							Description: "", Name: "Type", Type: "ImageSourceType", SerializationInfo: "`json:\"type,omitempty\" yaml:\"type,omitempty\"`"},
+							Description: "", Name: "Type", Type: "ImageSourceType", SerializationInfo: "`json:\"type,omitempty\" yaml:\"type,omitempty\"`",
+						},
 						{
 							Description: "", Name: "Url", Type: "string", SerializationInfo: "`json:\"url,omitempty\" yaml:\"url,omitempty\"`",
 						},
@@ -253,7 +269,8 @@ func Test_createOneOf(t *testing.T) {
 						{
 							Description: "", Name: "Id", Type: "string", SerializationInfo: "`json:\"id,omitempty\" yaml:\"id,omitempty\"`"},
 						{
-							Description: "", Name: "Type", Type: "ImageSourceType", SerializationInfo: "`json:\"type,omitempty\" yaml:\"type,omitempty\"`"},
+							Description: "", Name: "Type", Type: "ImageSourceType", SerializationInfo: "`json:\"type,omitempty\" yaml:\"type,omitempty\"`",
+						},
 					},
 				},
 				{
@@ -267,13 +284,18 @@ func Test_createOneOf(t *testing.T) {
 					},
 				},
 			},
+			want3: []EnumTemplate{
+				{Description: "// ImageSourceTypeUrl represents the ImageSourceType `\"url\"`.", Name: "ImageSourceTypeUrl", ValueType: "const", Value: "ImageSourceType = \"url\""},
+				{Description: "// ImageSourceTypeSnapshot represents the ImageSourceType `\"snapshot\"`.", Name: "ImageSourceTypeSnapshot", ValueType: "const", Value: "ImageSourceType = \"snapshot\""},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, typeTpls := createOneOf(tt.args.s, tt.args.name, tt.args.typeName)
+			got, typeTpls, enumTpls := createOneOf(tt.args.s, tt.args.name, tt.args.typeName)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.want2, typeTpls)
+			assert.Equal(t, tt.want3, enumTpls)
 		})
 	}
 }


### PR DESCRIPTION
Construct []TypeTemplate and []EnumTemplate to use instead of writing to file from several places, or saving the entire file in a string variable for enums.