### PR TITLE
Beginning of path gen refactor

### DIFF
--- a/internal/generate/paths.go
+++ b/internal/generate/paths.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -35,76 +34,79 @@ func generatePaths(file string, spec *openapi3.T) error {
 			continue
 		}
 
-		if err := writePath(spec, f, path, p); err != nil {
+		str, err := writePath(spec, path, p)
+		if err != nil {
 			return err
 		}
+		fmt.Fprint(f, str)
 	}
 
 	return nil
 }
 
 // writePath writes the given path as an http request to the given file.
-func writePath(spec *openapi3.T, f *os.File, path string, p *openapi3.PathItem) error {
+func writePath(spec *openapi3.T, path string, p *openapi3.PathItem) (string, error) {
+	var pathStr string
 	if p.Get != nil {
-		str, err := writeMethod(spec, f, http.MethodGet, path, p.Get, false)
+		str, err := writeMethod(spec, http.MethodGet, path, p.Get, false)
 		if err != nil {
-			return err
+			return "", err
 		}
-		fmt.Fprint(f, str)
+		pathStr = pathStr + fmt.Sprint(str)
 	}
 
 	if p.Post != nil {
-		str, err := writeMethod(spec, f, http.MethodPost, path, p.Post, false)
+		str, err := writeMethod(spec, http.MethodPost, path, p.Post, false)
 		if err != nil {
-			return err
+			return "", err
 		}
-		fmt.Fprint(f, str)
+		pathStr = pathStr + fmt.Sprint(str)
 	}
 
 	if p.Put != nil {
-		str, err := writeMethod(spec, f, http.MethodPut, path, p.Put, false)
+		str, err := writeMethod(spec, http.MethodPut, path, p.Put, false)
 		if err != nil {
-			return err
+			return "", err
 		}
-		fmt.Fprint(f, str)
+		pathStr = pathStr + fmt.Sprint(str)
 	}
 
 	if p.Delete != nil {
-		str, err := writeMethod(spec, f, http.MethodDelete, path, p.Delete, false)
+		str, err := writeMethod(spec, http.MethodDelete, path, p.Delete, false)
 		if err != nil {
-			return err
+			return "", err
 		}
-		fmt.Fprint(f, str)
+		pathStr = pathStr + fmt.Sprint(str)
 	}
 
 	if p.Patch != nil {
-		str, err := writeMethod(spec, f, http.MethodPatch, path, p.Patch, false)
+		str, err := writeMethod(spec, http.MethodPatch, path, p.Patch, false)
 		if err != nil {
-			return err
+			return "", err
 		}
-		fmt.Fprint(f, str)
+		pathStr = pathStr + fmt.Sprint(str)
 	}
 
 	if p.Head != nil {
-		str, err := writeMethod(spec, f, http.MethodHead, path, p.Head, false)
+		str, err := writeMethod(spec, http.MethodHead, path, p.Head, false)
 		if err != nil {
-			return err
+			return "", err
 		}
-		fmt.Fprint(f, str)
+		pathStr = pathStr + fmt.Sprint(str)
 	}
 
 	if p.Options != nil {
-		str, err := writeMethod(spec, f, http.MethodOptions, path, p.Options, false)
+		str, err := writeMethod(spec, http.MethodOptions, path, p.Options, false)
 		if err != nil {
-			return err
+			return "", err
 		}
-		fmt.Fprint(f, str)
+		pathStr = pathStr + fmt.Sprint(str)
 	}
 
-	return nil
+	return pathStr, nil
 }
 
-func writeMethod(spec *openapi3.T, f *os.File, method string, path string, o *openapi3.Operation, isGetAllPages bool) (string, error) {
+func writeMethod(spec *openapi3.T, method string, path string, o *openapi3.Operation, isGetAllPages bool) (string, error) {
 	var methodStr string
 
 	respType, pagedRespType, err := getSuccessResponseType(o, isGetAllPages)
@@ -243,7 +245,6 @@ func writeMethod(spec *openapi3.T, f *os.File, method string, path string, o *op
 
 	// Write the description to the file.
 	methodStr = methodStr + description.String()
-	//fmt.Fprint(f, description.String())
 
 	// Write the method.
 	if respType != "" && respType != "ConsumeCredentialsResponse" && respType != "LoginResponse" {
@@ -251,20 +252,14 @@ func writeMethod(spec *openapi3.T, f *os.File, method string, path string, o *op
 			fnName,
 			paramsString,
 			respType)
-		//		fmt.Fprintf(f, "func (c *Client) %s(%s) (*%s, error) {\n",
-		//			fnName,
-		//			paramsString,
-		//			respType)
 	} else {
 		methodStr = methodStr + fmt.Sprintf("func (c *Client) %s(%s) (error) {\n",
 			fnName,
 			paramsString)
-		//		fmt.Fprintf(f, "func (c *Client) %s(%s) (error) {\n",
-		//			fnName,
-		//			paramsString)
 	}
 
 	if len(pagedRespType) > 0 {
+		// We want to just recursively call the method for each page.
 		methodStr = methodStr + fmt.Sprintf(`
 			var allPages %s
 			pageToken := ""
@@ -284,26 +279,6 @@ func writeMethod(spec *openapi3.T, f *os.File, method string, path string, o *op
 			return &allPages, nil
 		}`, pagedRespType, ogFnName, ogDocParamsString)
 
-		// We want to just recursively call the method for each page.
-		//	fmt.Fprintf(f, `
-		//		var allPages %s
-		//		pageToken := ""
-		//		limit := 100
-		//		for {
-		//			page, err := c.%s(%s)
-		//			if err != nil {
-		//				return nil, err
-		//			}
-		//			allPages = append(allPages, page.Items...)
-		//			if  page.NextPage == "" || page.NextPage == pageToken {
-		//				break
-		//			}
-		//			pageToken = page.NextPage
-		//	}
-		//
-		//		return &allPages, nil
-		//	}`, pagedRespType, ogFnName, ogDocParamsString)
-
 		// Return early.
 		return methodStr, nil
 	}
@@ -312,10 +287,6 @@ func writeMethod(spec *openapi3.T, f *os.File, method string, path string, o *op
 	methodStr = methodStr + fmt.Sprintln("// Create the url.")
 	methodStr = methodStr + fmt.Sprintf("path := %q\n", cleanPath(path))
 	methodStr = methodStr + fmt.Sprintln("uri := resolveRelative(c.server, path)")
-
-	//	fmt.Fprintln(f, "// Create the url.")
-	//	fmt.Fprintf(f, "path := %q\n", cleanPath(path))
-	//	fmt.Fprintln(f, "uri := resolveRelative(c.server, path)")
 
 	if o.RequestBody != nil {
 		for mt := range o.RequestBody.Value.Content {
@@ -329,23 +300,16 @@ func writeMethod(spec *openapi3.T, f *os.File, method string, path string, o *op
 			methodStr = methodStr + fmt.Sprintln("b := new(bytes.Buffer)")
 			methodStr = methodStr + fmt.Sprintln("if err := json.NewEncoder(b).Encode(j); err != nil {")
 
-			// fmt.Fprintln(f, "// Encode the request body as json.")
-			// fmt.Fprintln(f, "b := new(bytes.Buffer)")
-			// fmt.Fprintln(f, "if err := json.NewEncoder(b).Encode(j); err != nil {")
 			if respType != "" {
 				r := `return nil, fmt.Errorf("encoding json body request failed: %v", err)`
 				methodStr = methodStr + fmt.Sprintln(r)
-
-				// fmt.Fprintln(f, r)
 			} else {
 				r := `return fmt.Errorf("encoding json body request failed: %v", err)`
 				methodStr = methodStr + fmt.Sprintln(r)
-
-				// fmt.Fprintln(f, r)
 			}
 
 			methodStr = methodStr + fmt.Sprintln("}")
-			//fmt.Fprintln(f, "}")
+
 			reqBodyParam = "b"
 			break
 		}
@@ -354,31 +318,22 @@ func writeMethod(spec *openapi3.T, f *os.File, method string, path string, o *op
 
 	// Create the request.
 	methodStr = methodStr + fmt.Sprintln("// Create the request.")
-	//fmt.Fprintln(f, "// Create the request.")
-
 	methodStr = methodStr + fmt.Sprintf("req, err := http.NewRequest(%q, uri, %s)\n", method, reqBodyParam)
 	methodStr = methodStr + fmt.Sprintln("if err != nil {")
-	// fmt.Fprintf(f, "req, err := http.NewRequest(%q, uri, %s)\n", method, reqBodyParam)
-	// fmt.Fprintln(f, "if err != nil {")
 
 	if respType != "" && respType != "ConsumeCredentialsResponse" && respType != "LoginResponse" {
 		r := `return nil, fmt.Errorf("error creating request: %v", err)`
 		methodStr = methodStr + fmt.Sprintln(r)
-		//		fmt.Fprintln(f, r)
 	} else {
 		r := `return fmt.Errorf("error creating request: %v", err)`
 		methodStr = methodStr + fmt.Sprintln(r)
-		//		fmt.Fprintln(f, r)
 	}
 	methodStr = methodStr + fmt.Sprintln("}")
-	//	fmt.Fprintln(f, "}")
 
 	// Add the parameters to the url.
 	if len(params) > 0 {
 		methodStr = methodStr + fmt.Sprintln("// Add the parameters to the url.")
 		methodStr = methodStr + fmt.Sprintln("if err := expandURL(req.URL, map[string]string{")
-		// fmt.Fprintln(f, "// Add the parameters to the url.")
-		// fmt.Fprintln(f, "if err := expandURL(req.URL, map[string]string{")
 
 		// Iterate over all the paths in the spec and write the types.
 		// We want to ensure we keep the order so the diffs don't look like shit.
@@ -393,69 +348,50 @@ func writeMethod(spec *openapi3.T, f *os.File, method string, path string, o *op
 			n := strcase.ToLowerCamel(name)
 			if t == "string" {
 				methodStr = methodStr + fmt.Sprintf("	%q: %s,\n", name, n)
-				// fmt.Fprintf(f, "	%q: %s,\n", name, n)
 			} else if t == "int" {
 				methodStr = methodStr + fmt.Sprintf("	%q: strconv.Itoa(%s),\n", name, n)
-				// fmt.Fprintf(f, "	%q: strconv.Itoa(%s),\n", name, n)
 			} else if t == "*time.Time" {
 				methodStr = methodStr + fmt.Sprintf("	%q: %s.String(),\n", name, n)
-				// fmt.Fprintf(f, "	%q: %s.String(),\n", name, n)
 			} else {
 				methodStr = methodStr + fmt.Sprintf("	%q: string(%s),\n", name, n)
-				// fmt.Fprintf(f, "	%q: string(%s),\n", name, n)
 			}
 		}
 		methodStr = methodStr + fmt.Sprintln("}); err != nil {")
-		// fmt.Fprintln(f, "}); err != nil {")
 		if respType != "" && respType != "ConsumeCredentialsResponse" && respType != "LoginResponse" {
 			r := `return nil, fmt.Errorf("expanding URL with parameters failed: %v", err)`
 			methodStr = methodStr + fmt.Sprintln(r)
-			// fmt.Fprintln(f, r)
 		} else {
 			r := `return fmt.Errorf("expanding URL with parameters failed: %v", err)`
 			methodStr = methodStr + fmt.Sprintln(r)
-			// fmt.Fprintln(f, r)
 		}
 		methodStr = methodStr + fmt.Sprintln("}")
-		//		fmt.Fprintln(f, "}")
 	}
 
 	// Send the request.
 	methodStr = methodStr + fmt.Sprintln("// Send the request.")
 	methodStr = methodStr + fmt.Sprintln("resp, err := c.client.Do(req)")
 	methodStr = methodStr + fmt.Sprintln("if err != nil {")
-	// fmt.Fprintln(f, "// Send the request.")
-	// fmt.Fprintln(f, "resp, err := c.client.Do(req)")
-	// fmt.Fprintln(f, "if err != nil {")
 
 	if respType != "" && respType != "ConsumeCredentialsResponse" && respType != "LoginResponse" {
 		r := `return nil, fmt.Errorf("error sending request: %v", err)`
 		methodStr = methodStr + fmt.Sprintln(r)
-		// fmt.Fprintln(f, r)
 	} else {
 		r := `return fmt.Errorf("error sending request: %v", err)`
 		methodStr = methodStr + fmt.Sprintln(r)
-		// fmt.Fprintln(f, r)
 	}
 	methodStr = methodStr + fmt.Sprintln("}")
 	methodStr = methodStr + fmt.Sprintln("defer resp.Body.Close()")
-	//	fmt.Fprintln(f, "}")
-	//	fmt.Fprintln(f, "defer resp.Body.Close()")
 
 	// Check the response if there were any errors.
 	methodStr = methodStr + fmt.Sprintln("// Check the response.")
 	methodStr = methodStr + fmt.Sprintln("if err := checkResponse(resp); err != nil {")
-	//	fmt.Fprintln(f, "// Check the response.")
-	//	fmt.Fprintln(f, "if err := checkResponse(resp); err != nil {")
+
 	if respType != "" && respType != "ConsumeCredentialsResponse" && respType != "LoginResponse" {
 		methodStr = methodStr + fmt.Sprintln("return nil, err")
-		// fmt.Fprintln(f, "return nil, err")
 	} else {
 		methodStr = methodStr + fmt.Sprintln("return err")
-		// fmt.Fprintln(f, "return err")
 	}
 	methodStr = methodStr + fmt.Sprintln("}")
-	// fmt.Fprintln(f, "}")
 
 	if respType != "" && respType != "ConsumeCredentialsResponse" && respType != "LoginResponse" {
 		// Decode the body from the response.
@@ -463,43 +399,29 @@ func writeMethod(spec *openapi3.T, f *os.File, method string, path string, o *op
 		methodStr = methodStr + fmt.Sprintln("if resp.Body == nil {")
 		methodStr = methodStr + fmt.Sprintln(`return nil, errors.New("request returned an empty body in the response")`)
 		methodStr = methodStr + fmt.Sprintln("}")
-		//fmt.Fprintln(f, "// Decode the body from the response.")
-		//fmt.Fprintln(f, "if resp.Body == nil {")
-		//fmt.Fprintln(f, `return nil, errors.New("request returned an empty body in the response")`)
-		//fmt.Fprintln(f, "}")
 
 		methodStr = methodStr + fmt.Sprintf("var body %s\n", respType)
 		methodStr = methodStr + fmt.Sprintln("if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {")
-		//		fmt.Fprintf(f, "var body %s\n", respType)
-		//		fmt.Fprintln(f, "if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {")
 		r := `return nil, fmt.Errorf("error decoding response body: %v", err)`
 		methodStr = methodStr + fmt.Sprintln(r)
-		// fmt.Fprintln(f, r)
 
 		methodStr = methodStr + fmt.Sprintln("}")
-		//fmt.Fprintln(f, "}")
 
 		// Return the response.
 		methodStr = methodStr + fmt.Sprintln("// Return the response.")
 		methodStr = methodStr + fmt.Sprintln("return &body, nil")
-		//		fmt.Fprintln(f, "// Return the response.")
-		//		fmt.Fprintln(f, "return &body, nil")
 	} else {
 		methodStr = methodStr + fmt.Sprintln("// Return.")
 		methodStr = methodStr + fmt.Sprintln("return nil")
-		// fmt.Fprintln(f, "// Return.")
-		// fmt.Fprintln(f, "return nil")
 	}
 
 	// Close the method.
 	methodStr = methodStr + fmt.Sprintln("}")
 	methodStr = methodStr + fmt.Sprintln("")
-	//	fmt.Fprintln(f, "}")
-	//	fmt.Fprintln(f, "")
 
 	if pageResult && !isGetAllPages {
 		// Run the method again with get all pages.
-		str, err := writeMethod(spec, f, method, path, o, true)
+		str, err := writeMethod(spec, method, path, o, true)
 		if err != nil {
 			return "", err
 		}

--- a/internal/generate/templates/test.tpl
+++ b/internal/generate/templates/test.tpl
@@ -1,0 +1,1 @@
+The operation ID is {{.id}}

--- a/internal/generate/test_utils/tpl_test
+++ b/internal/generate/test_utils/tpl_test
@@ -1,0 +1,1 @@
+The operation ID is ip-pool-view


### PR DESCRIPTION
This commit modifies the paths.go generation functions to only write to file from a single place. Eventually templates will be used instead of forming the structure with several `fmt.Printf()`, a small testing function for this was added.

Additionally, the `writeMethod()` function has been separated into two to begin the work of having different functions for methods if necessary.

