### PR TITLE
Handle nested allOf references types within oneOfs

### DIFF
--- a/internal/generate/types.go
+++ b/internal/generate/types.go
@@ -127,6 +127,11 @@ func constructEnums(enumStrCollection map[string][]string) []EnumTemplate {
 			// Most likely, the enum values are strings.
 			enumItems = enumItems + fmt.Sprintf("\t%s,\n", strcase.ToCamel(fmt.Sprintf("%s_%s", makeSingular(name), enum)))
 		}
+
+		if enumItems == "" {
+			continue
+		}
+
 		enumVar := fmt.Sprintf("= []%s{\n", makeSingular(name)) + enumItems + "}"
 
 		enumTpl := EnumTemplate{
@@ -245,10 +250,9 @@ func populateTypeTemplates(name string, s *openapi3.Schema, additionalName strin
 		fmt.Printf("[WARN] TODO: skipping type for %q, since it is a ANYOF\n", name)
 	case "all_of":
 		// TODO: This approach works for the current usage of "allOf". Monitor to see if this changes
-		enums, tt := createAllOf(s, collectEnumStringTypes, name, typeName)
+		tt := createAllOf(s, collectEnumStringTypes, name, typeName)
 		types = append(types, tt...)
-		// enumTypes = append(enumTypes, et...)
-		collectEnumStringTypes = enums
+
 	default:
 		fmt.Printf("[WARN] TODO: skipping type for %q, since it is an unknown type\n", name)
 	}
@@ -364,7 +368,7 @@ func createStringEnum(s *openapi3.Schema, stringEnums map[string][]string, name,
 //
 // Probably not the best approach, but will leave them this way until I come up with
 // a more idiomatic solution. Keep an eye out on this one to refine.
-func createAllOf(s *openapi3.Schema, stringEnums map[string][]string, name, typeName string) (map[string][]string, []TypeTemplate) {
+func createAllOf(s *openapi3.Schema, stringEnums map[string][]string, name, typeName string) []TypeTemplate {
 	singularTypename := makeSingular(typeName)
 	singularName := makeSingular(name)
 	typeTpls := make([]TypeTemplate, 0)
@@ -382,27 +386,7 @@ func createAllOf(s *openapi3.Schema, stringEnums map[string][]string, name, type
 		stringEnums[singularTypename] = []string{}
 	}
 
-	// TODO: Not entirely sure these additional enum types are necessary, but let's keep them for now
-	//	enumTpls := make([]EnumTemplate, 0)
-	//	for _, v := range s.AllOf {
-	//		enum := getReferenceSchema(v)
-	//
-	//		snakeCaseTypeName := fmt.Sprintf("%s_%s", singularName, enum)
-	//
-	//		enumTpl := EnumTemplate{
-	//			Description: fmt.Sprintf("// %s represents the %s `%q`.", strcase.ToCamel(snakeCaseTypeName), singularName, enum),
-	//			Name:        strcase.ToCamel(snakeCaseTypeName),
-	//			ValueType:   "const",
-	//			Value:       fmt.Sprintf("%s = %q", singularName, strings.ToLower(enum)),
-	//		}
-	//
-	//		enumTpls = append(enumTpls, enumTpl)
-	//
-	//		// Add the enum type to the list of enum types.
-	//		stringEnums[singularTypename] = append(stringEnums[singularTypename], enum)
-	//	}
-
-	return stringEnums, typeTpls //, enumTpls
+	return typeTpls
 }
 
 func createOneOf(s *openapi3.Schema, name, typeName string) ([]TypeTemplate, []EnumTemplate) {

--- a/internal/generate/types.go
+++ b/internal/generate/types.go
@@ -245,9 +245,9 @@ func populateTypeTemplates(name string, s *openapi3.Schema, additionalName strin
 		fmt.Printf("[WARN] TODO: skipping type for %q, since it is a ANYOF\n", name)
 	case "all_of":
 		// TODO: This approach works for the current usage of "allOf". Monitor to see if this changes
-		enums, tt, et := createAllOf(s, collectEnumStringTypes, name, typeName)
+		enums, tt := createAllOf(s, collectEnumStringTypes, name, typeName)
 		types = append(types, tt...)
-		enumTypes = append(enumTypes, et...)
+		// enumTypes = append(enumTypes, et...)
 		collectEnumStringTypes = enums
 	default:
 		fmt.Printf("[WARN] TODO: skipping type for %q, since it is an unknown type\n", name)
@@ -352,9 +352,19 @@ func createStringEnum(s *openapi3.Schema, stringEnums map[string][]string, name,
 	return stringEnums, typeTpls, enumTpls
 }
 
-// TODO: For now AllOf values are treated as enums because that's how they are being used.
-// Keep an eye out to see if this changes
-func createAllOf(s *openapi3.Schema, stringEnums map[string][]string, name, typeName string) (map[string][]string, []TypeTemplate, []EnumTemplate) {
+// TODO: For now AllOf values are treated as interfaces. This way you can pass whichever
+// of the struct types you need like this:
+//
+// ipRange := oxide.Ipv4Range{
+// 	 First: "172.20.15.240",
+// 	 Last:  "172.20.15.250",
+// }
+// body := oxide.IpRange(ipRange)
+// resp, err := client.IpPoolRangeAdd("mypool", &body)
+//
+// Probably not the best approach, but will leave them this way until I come up with
+// a more idiomatic solution. Keep an eye out on this one to refine.
+func createAllOf(s *openapi3.Schema, stringEnums map[string][]string, name, typeName string) (map[string][]string, []TypeTemplate) {
 	singularTypename := makeSingular(typeName)
 	singularName := makeSingular(name)
 	typeTpls := make([]TypeTemplate, 0)
@@ -364,7 +374,7 @@ func createAllOf(s *openapi3.Schema, stringEnums map[string][]string, name, type
 		typeTpl := TypeTemplate{
 			Description: formatTypeDescription(singularName, s),
 			Name:        singularTypename,
-			Type:        "string",
+			Type:        "interface{}",
 		}
 
 		typeTpls = append(typeTpls, typeTpl)
@@ -372,26 +382,27 @@ func createAllOf(s *openapi3.Schema, stringEnums map[string][]string, name, type
 		stringEnums[singularTypename] = []string{}
 	}
 
-	enumTpls := make([]EnumTemplate, 0)
-	for _, v := range s.AllOf {
-		enum := getReferenceSchema(v)
+	// TODO: Not entirely sure these additional enum types are necessary, but let's keep them for now
+	//	enumTpls := make([]EnumTemplate, 0)
+	//	for _, v := range s.AllOf {
+	//		enum := getReferenceSchema(v)
+	//
+	//		snakeCaseTypeName := fmt.Sprintf("%s_%s", singularName, enum)
+	//
+	//		enumTpl := EnumTemplate{
+	//			Description: fmt.Sprintf("// %s represents the %s `%q`.", strcase.ToCamel(snakeCaseTypeName), singularName, enum),
+	//			Name:        strcase.ToCamel(snakeCaseTypeName),
+	//			ValueType:   "const",
+	//			Value:       fmt.Sprintf("%s = %q", singularName, strings.ToLower(enum)),
+	//		}
+	//
+	//		enumTpls = append(enumTpls, enumTpl)
+	//
+	//		// Add the enum type to the list of enum types.
+	//		stringEnums[singularTypename] = append(stringEnums[singularTypename], enum)
+	//	}
 
-		snakeCaseTypeName := fmt.Sprintf("%s_%s", singularName, enum)
-
-		enumTpl := EnumTemplate{
-			Description: fmt.Sprintf("// %s represents the %s `%q`.", strcase.ToCamel(snakeCaseTypeName), singularName, enum),
-			Name:        strcase.ToCamel(snakeCaseTypeName),
-			ValueType:   "const",
-			Value:       fmt.Sprintf("%s = %q", singularName, strings.ToLower(enum)),
-		}
-
-		enumTpls = append(enumTpls, enumTpl)
-
-		// Add the enum type to the list of enum types.
-		stringEnums[singularTypename] = append(stringEnums[singularTypename], enum)
-	}
-
-	return stringEnums, typeTpls, enumTpls
+	return stringEnums, typeTpls //, enumTpls
 }
 
 func createOneOf(s *openapi3.Schema, name, typeName string) ([]TypeTemplate, []EnumTemplate) {

--- a/internal/generate/types_test.go
+++ b/internal/generate/types_test.go
@@ -334,10 +334,10 @@ func Test_createAllOf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
-				got, got1, got2 := createAllOf(tt.args.s, tt.args.stringEnums, tt.args.name, tt.args.typeName)
+				got, got1 := createAllOf(tt.args.s, tt.args.stringEnums, tt.args.name, tt.args.typeName)
 				assert.Equal(t, tt.want, got)
 				assert.Equal(t, tt.want1, got1)
-				assert.Equal(t, tt.want2, got2)
+				//assert.Equal(t, tt.want2, got2)
 			})
 		})
 	}

--- a/internal/generate/types_test.go
+++ b/internal/generate/types_test.go
@@ -309,24 +309,16 @@ func Test_createAllOf(t *testing.T) {
 		typeName    string
 	}
 	tests := []struct {
-		name  string
-		args  args
-		want  map[string][]string
-		want1 []TypeTemplate
-		want2 []EnumTemplate
+		name string
+		args args
+		want []TypeTemplate
 	}{
 		{
 			name: "success allOf",
 			args: args{typeSpecAllOf, enums, "IpRange", "IpRange"},
-			want: map[string][]string{"IpRange": {"Ipv4Range"}},
-			want1: []TypeTemplate{
+			want: []TypeTemplate{
 				{
-					Description: "// IpRange is the type definition for a IpRange.", Name: "IpRange", Type: "string",
-				},
-			},
-			want2: []EnumTemplate{
-				{
-					Description: "// IpRangeIpv4Range represents the IpRange `\"Ipv4Range\"`.", Name: "IpRangeIpv4Range", ValueType: "const", Value: "IpRange = \"ipv4range\"",
+					Description: "// IpRange is the type definition for a IpRange.", Name: "IpRange", Type: "interface{}",
 				},
 			},
 		},
@@ -334,10 +326,8 @@ func Test_createAllOf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
-				got, got1 := createAllOf(tt.args.s, tt.args.stringEnums, tt.args.name, tt.args.typeName)
+				got := createAllOf(tt.args.s, tt.args.stringEnums, tt.args.name, tt.args.typeName)
 				assert.Equal(t, tt.want, got)
-				assert.Equal(t, tt.want1, got1)
-				//assert.Equal(t, tt.want2, got2)
 			})
 		})
 	}

--- a/oxide/types.go
+++ b/oxide/types.go
@@ -866,7 +866,7 @@ type InstanceState string
 type IpKind string
 
 // IpNet is the type definition for a IpNet.
-type IpNet string
+type IpNet interface{}
 
 // IpPool is identity-related metadata that's included in nearly all public API objects
 type IpPool struct {
@@ -926,7 +926,7 @@ type IpPoolUpdate struct {
 }
 
 // IpRange is the type definition for a IpRange.
-type IpRange string
+type IpRange interface{}
 
 // Ipv4Net is an IPv4 subnet, including prefix and subnet mask
 type Ipv4Net string
@@ -2225,18 +2225,6 @@ const IpKindEphemeral IpKind = "ephemeral"
 // IpKindFloating represents the IpKind `"floating"`.
 const IpKindFloating IpKind = "floating"
 
-// IpNetIpv4Net represents the IpNet `"Ipv4Net"`.
-const IpNetIpv4Net IpNet = "ipv4net"
-
-// IpNetIpv6Net represents the IpNet `"Ipv6Net"`.
-const IpNetIpv6Net IpNet = "ipv6net"
-
-// IpRangeIpv4Range represents the IpRange `"Ipv4Range"`.
-const IpRangeIpv4Range IpRange = "ipv4range"
-
-// IpRangeIpv6Range represents the IpRange `"Ipv6Range"`.
-const IpRangeIpv6Range IpRange = "ipv6range"
-
 // NameOrIdSortModeNameAscending represents the NameOrIdSortMode `"name_ascending"`.
 const NameOrIdSortModeNameAscending NameOrIdSortMode = "name_ascending"
 
@@ -2571,16 +2559,10 @@ var IpKinds = []IpKind{
 }
 
 // IpNets is the collection of all IpNet values.
-var IpNets = []IpNet{
-	IpNetIpv4Net,
-	IpNetIpv6Net,
-}
+var IpNets = []IpNet{}
 
 // IpRanges is the collection of all IpRange values.
-var IpRanges = []IpRange{
-	IpRangeIpv4Range,
-	IpRangeIpv6Range,
-}
+var IpRanges = []IpRange{}
 
 // NameOrIdSortModes is the collection of all NameOrIdSortMode values.
 var NameOrIdSortModes = []NameOrIdSortMode{

--- a/oxide/types.go
+++ b/oxide/types.go
@@ -2558,12 +2558,6 @@ var IpKinds = []IpKind{
 	IpKindFloating,
 }
 
-// IpNets is the collection of all IpNet values.
-var IpNets = []IpNet{}
-
-// IpRanges is the collection of all IpRange values.
-var IpRanges = []IpRange{}
-
 // NameOrIdSortModes is the collection of all NameOrIdSortMode values.
 var NameOrIdSortModes = []NameOrIdSortMode{
 	NameOrIdSortModeIdAscending,


### PR DESCRIPTION
 For now these values are treated as interfaces. This way you can pass whichever
 of the struct types you need like this:

```go
ipRange := oxide.Ipv4Range{
	First: "172.20.15.240",
	Last:  "172.20.15.250",
}

body := oxide.IpRange(ipRange)
resp, _ := client.IpPoolRangeAdd("mypool", &body)
```
 Probably not the best approach, but will leave them this way until I come up with
 a more idiomatic solution. Keep an eye out on this one to refine.

Closes: https://github.com/oxidecomputer/oxide.go/issues/72