### PR TITLE
Initial validator implementation

### DIFF
--- a/oxide/validate.go
+++ b/oxide/validate.go
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package oxide
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Validator is a helper to validate the Client methods
+type Validator struct {
+	// TODO: Capture multiple errors
+	err error
+}
+
+// HasRequiredStr checks for an empty string
+func (v *Validator) HasRequiredStr(value string) bool {
+	if value == "" {
+		v.err = fmt.Errorf("required value is an empty string")
+		return false
+	}
+	return true
+}
+
+// HasRequiredNum checks for an empty string
+func (v *Validator) HasRequiredNum(value int) bool {
+	if value == 0 {
+		v.err = fmt.Errorf("required value is zero")
+		return false
+	}
+	return true
+}
+
+// HasRequiredObj checks for a nil value
+// The argument must be a chan, func, interface, map,
+// pointer, or slice value
+func (v *Validator) HasRequiredObj(value any) bool {
+	// Unfortunately generics are a little tricky when
+	// dealing with nil values, so we have to use reflect here.
+	if value == nil || reflect.ValueOf(value).IsNil() {
+		v.err = fmt.Errorf("required value is nil")
+		return false
+	}
+	return true
+}
+
+// IsValid returns false if the Validator contains
+// any validation errors
+func (v *Validator) IsValid() bool {
+	return v.err == nil
+}
+
+// Error is the string representation of a validation
+// error
+func (v *Validator) Error() string {
+	return v.err.Error()
+}

--- a/oxide/validate_test.go
+++ b/oxide/validate_test.go
@@ -1,0 +1,146 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package oxide
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidator_HasRequiredStr(t *testing.T) {
+	type fields struct {
+		err error
+	}
+	type args struct {
+		value string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    bool
+		wantErr error
+	}{
+		{
+			name:   "string is present",
+			fields: fields{},
+			args: args{
+				value: "some string",
+			},
+			want: true,
+		},
+		{
+			name:   "string is not present",
+			fields: fields{},
+			args: args{
+				value: "",
+			},
+			want:    false,
+			wantErr: fmt.Errorf("required value is an empty string"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Validator{
+				err: tt.fields.err,
+			}
+			got := v.HasRequiredStr(tt.args.value)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantErr, v.err)
+
+		})
+	}
+}
+
+func TestValidator_HasRequiredObj(t *testing.T) {
+	val := "hi"
+	type fields struct {
+		err error
+	}
+	type args struct {
+		value any
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    bool
+		wantErr error
+	}{
+		{
+			name:   "object is present",
+			fields: fields{},
+			args: args{
+				value: &val,
+			},
+			want: true,
+		},
+		{
+			name:   "object is not present",
+			fields: fields{},
+			args: args{
+				value: nil,
+			},
+			want:    false,
+			wantErr: fmt.Errorf("required value is nil"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Validator{
+				err: tt.fields.err,
+			}
+			got := v.HasRequiredObj(tt.args.value)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantErr, v.err)
+
+		})
+	}
+}
+
+func TestValidator_HasRequiredNum(t *testing.T) {
+	type fields struct {
+		err error
+	}
+	type args struct {
+		value int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    bool
+		wantErr error
+	}{
+		{
+			name:   "int is present",
+			fields: fields{},
+			args: args{
+				value: 1,
+			},
+			want: true,
+		},
+		{
+			name:    "int is not present",
+			fields:  fields{},
+			args:    args{},
+			want:    false,
+			wantErr: fmt.Errorf("required value is zero"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Validator{
+				err: tt.fields.err,
+			}
+			got := v.HasRequiredNum(tt.args.value)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantErr, v.err)
+
+		})
+	}
+}


### PR DESCRIPTION
Related: https://github.com/oxidecomputer/oxide.go/issues/37

With this implementation of a validator there are a few ways to go on about validating the methods:

## Option 1
Directly inside the client methods. The end user doesn't have to worry about thinking about validation
```go
// Generated code
func (c *Client) ProjectCreate(params ProjectCreateParams) (*Project, error) {
	v := new(Validator)
	v.HasRequiredObj(params.Body)
        v.HasRequiredStr(params.SomeString)
        // Add more checks if necessary
	if !v.IsValid() {
		return nil, fmt.Errorf("validation error: %v", v.Error())
	}
<...>
```

## Option 2
Into custom validators for each params type. We can choose to integrate the validation methods into the client methods or have the end users decide to use the validators or not.
```go
// Generated code
type ProjectCreateParams struct {
	Body       *ProjectCreate `json:"body,omitempty" yaml:"body,omitempty"`
        SomeString string         `json:"some_string,omitempty" yaml:"some_string,omitempty"`
}

func (p *ProjectCreateParams) Validate() error {
	v := new(Validator)
	v.HasRequiredObj(p.Body)
	v.HasRequiredStr(p.SomeString)
         // Add more checks if necessary
	if !v.IsValid() {
		return nil, fmt.Errorf("validation error: %v", v.Error())
	}
	return nil
}
```

### Option 2.1
Using the generated validators from option 2 and give the user the choice to validate or not
```go
// End user code
client, err := oxide.NewClient()
params := oxide.ProjectCreateParams{Body: nil}
err := params.Validate() // This would fail as the Body is empty
resp, err := client.ProjectCreate(params)
```

### Option 2.2
Using the generated validators from option 2 generate the methods with the validator methods
```go
// Generated code
func (c *Client) ProjectCreate(params ProjectCreateParams) (*Project, error) {
	err := params.Validate()
<...>
```
