### PR TITLE
Retract unecessary versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+	[v0.0.7-rc.1, v0.0.7-rc.6]
+	[v0.0.1, v0.0.22]
+)


### PR DESCRIPTION
Closes: https://github.com/oxidecomputer/oxide.go/issues/146

We would like to start with a clean slate with version v0.1.0-beta1. These previous versions were published prematurely