### PR TITLE
Implement changelog automation and makefile clean up

### DIFF
--- a/.changelog/v0.1.0-beta2.toml
+++ b/.changelog/v0.1.0-beta2.toml
@@ -1,0 +1,7 @@
+[[bugs]]
+
+[[features]]
+
+[[enhancements]]
+
+[[breaking]]

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,12 +30,10 @@ jobs:
       - name: lint
         shell: bash
         run: |
-          go get golang.org/x/lint/golint
           make lint
       - name: staticcheck
         shell: bash
         run: |
-          go get honnef.co/go/tools/cmd/staticcheck@latest
           make staticcheck
       - name: vet
         shell: bash
@@ -45,9 +43,4 @@ jobs:
         shell: bash
         run: |
           make fmt
-      - name: make test coverage
-        shell: bash
-        run: |
-          make cover
-        env:
-          OXIDE_API_TOKEN: ${{secrets.OXIDE_API_TOKEN}}
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 internal/generate/test_utils/tpl_method*
+bin/
+.crates.toml
+.crates2.json

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ vet: ## Verifies `go vet` passes.
 .PHONY: staticcheck
 staticcheck: tools ## Verifies `staticcheck` passes.
 	@ echo "+ Verifying staticcheck passes..."
-	@if [[ ! -z "$(shell staticcheck $(shell $(GO) list ./... | grep -v vendor) | tee /dev/stderr)" ]]; then \
+	@if [[ ! -z "$(shell $(GOBIN)/staticcheck $(shell $(GO) list ./... | grep -v vendor) | tee /dev/stderr)" ]]; then \
 		exit 1; \
 	fi
 

--- a/oxide/utils_test.go
+++ b/oxide/utils_test.go
@@ -40,7 +40,10 @@ func TestExpandURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parsing url %q failed: %v", test.in, err)
 		}
-		expandURL(u, test.expansions)
+		err = expandURL(u, test.expansions)
+		if err != nil {
+			t.Fatalf("expanding url with %v failed: %v", test.expansions, err)
+		}
 		got := u.String()
 		if got != test.want {
 			t.Errorf("got %q expected %q in test %d", got, test.want, i+1)


### PR DESCRIPTION
- Make target for creating a changelog
- Makefile will no longer download tooling every single time you call a target, and various fixes

Closes: https://github.com/oxidecomputer/oxide.go/issues/147