### PR TITLE
Fix VPC firewall rules delete action

### DIFF
--- a/.changelog/v0.1.0-beta2.toml
+++ b/.changelog/v0.1.0-beta2.toml
@@ -1,7 +1,3 @@
 [[bugs]]
-
-[[features]]
-
-[[enhancements]]
-
-[[breaking]]
+title = "Fix delete VPC firewall rules"
+description = "By removing `omitempty` when parsing the rules, we are able to pass an emtpy array to delete all firewall rules. [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)"

--- a/.changelog/v0.1.0-beta2.toml
+++ b/.changelog/v0.1.0-beta2.toml
@@ -1,3 +1,3 @@
 [[bugs]]
 title = "Fix delete VPC firewall rules"
-description = "By removing `omitempty` when parsing the rules, we are able to pass an emtpy array to delete all firewall rules. [#XXX](https://github.com/oxidecomputer/terraform-provider-oxide/pull/XXX)"
+description = "By removing `omitempty` when parsing the rules, we are able to pass an emtpy array to delete all firewall rules. [#158](https://github.com/oxidecomputer/terraform-provider-oxide/pull/158)"

--- a/internal/generate/exceptions.go
+++ b/internal/generate/exceptions.go
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main
+
+// Returns a list of types that should not be omitted when empty
+// for json serialisation
+func omitemptyExceptions() []string {
+	return []string{
+		"[]VpcFirewallRuleUpdate",
+	}
+}

--- a/internal/generate/types.go
+++ b/internal/generate/types.go
@@ -485,6 +485,11 @@ func createTypeObject(schemas map[string]*openapi3.SchemaRef, name, typeName, de
 		field.Name = strcase.ToCamel(k)
 		field.Type = typeName
 		serInfo := fmt.Sprintf("`json:\"%s,omitempty\" yaml:\"%s,omitempty\"`", k, k)
+		// There are a few types we do not want to omit if empty
+		// TODO: Keep an eye out to see if there is a way to identify all of these
+		if sliceContains(omitemptyExceptions(), typeName) {
+			serInfo = fmt.Sprintf("`json:\"%s\" yaml:\"%s\"`", k, k)
+		}
 		field.SerializationInfo = serInfo
 		fields = append(fields, field)
 

--- a/internal/generate/utils.go
+++ b/internal/generate/utils.go
@@ -223,3 +223,12 @@ func isNumericType(str string) bool {
 	}
 	return false
 }
+
+func sliceContains[T comparable](s []T, str T) bool {
+	for _, a := range s {
+		if a == str {
+			return true
+		}
+	}
+	return false
+}

--- a/oxide/types.go
+++ b/oxide/types.go
@@ -2843,7 +2843,7 @@ type VpcFirewallRuleUpdate struct {
 
 // VpcFirewallRuleUpdateParams is updateable properties of a `Vpc`'s firewall Note that VpcFirewallRules are implicitly created along with a Vpc, so there is no explicit creation.
 type VpcFirewallRuleUpdateParams struct {
-	Rules []VpcFirewallRuleUpdate `json:"rules,omitempty" yaml:"rules,omitempty"`
+	Rules []VpcFirewallRuleUpdate `json:"rules" yaml:"rules"`
 }
 
 // VpcFirewallRules is collection of a Vpc's firewall rules


### PR DESCRIPTION
Remove `omitempty` from the rules in `VpcFirewallRuleUpdateParams` to be able to delete all firewall rules