### PR TITLE
Don't hardcode Bash path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL = /usr/bin/env bash -eo pipefail
 NAME := oxide
 
 # If this session isn't interactive, then we don't want to allocate a


### PR DESCRIPTION
Users may not be using `/bin/bash` as their preferred shell. This is common on macOS, where Bash is commonly installed from Homebrew.

Update `SHELL` to use `/usr/bin/env` and set `-eo pipefail` to force jobs to exit on failure immediately.