### PR TITLE
Account for additional fields "array" types that don't specify map keys

### DIFF
--- a/.changelog/v0.1.0-beta9.toml
+++ b/.changelog/v0.1.0-beta9.toml
@@ -3,8 +3,8 @@ title = "OneOf generic types"
 description = "All struct field types that have different property types in the OpenAPI spec have now been set to `any`. [#234](https://github.com/oxidecomputer/oxide.go/pull/234)"
 
 [[features]]
-title = ""
-description = ""
+title = "Helper function"
+description = "New `NewPointer` function that returns a pointer to a given value. [235](https://github.com/oxidecomputer/oxide.go/pull/235)"
 
 [[enhancements]]
 title = ""
@@ -13,3 +13,7 @@ description = ""
 [[bugs]]
 title = "Fix for fields of type `time.Time`"
 description = "Change encoding of time parameters to RFC3339. [232](https://github.com/oxidecomputer/oxide.go/pull/232)"
+
+[[bugs]]
+title = "Fix for types"
+description = "Account for additional fields 'array' types that don't specify map keys. [235](https://github.com/oxidecomputer/oxide.go/pull/235)"

--- a/internal/generate/types.go
+++ b/internal/generate/types.go
@@ -519,6 +519,16 @@ func createTypeObject(schema *openapi3.Schema, name, typeName, description strin
 			typeName = fmt.Sprintf("%s%s", name, strcase.ToCamel(k))
 		}
 
+		// When additional properties is set and is type array, it means
+		// the type will be a map.
+		// TODO correctness: Currently our API spec does not specify what
+		// type the key will be, so we set it to string to avoid errors.
+		// If the type of the key is defined in our spec in the future,
+		// this should be changed to reflect that type.
+		if isObjectArray(v) {
+			typeName = fmt.Sprintf("map[string][]%s", typeName)
+		}
+
 		field := TypeFields{}
 		if v.Value.Description != "" {
 			desc := fmt.Sprintf("// %s is %s", strcase.ToCamel(k), toLowerFirstLetter(strings.ReplaceAll(v.Value.Description, "\n", "\n// ")))

--- a/internal/generate/utils.go
+++ b/internal/generate/utils.go
@@ -51,6 +51,14 @@ func isLocalObject(v *openapi3.SchemaRef) bool {
 	return v.Ref == "" && v.Value.Type.Is("object") && len(v.Value.Properties) > 0
 }
 
+func isObjectArray(v *openapi3.SchemaRef) bool {
+	if v.Value.AdditionalProperties.Schema != nil {
+		return v.Value.AdditionalProperties.Schema.Value.Type.Is("array")
+	}
+
+	return false
+}
+
 // formatStringType converts a string schema to a valid Go type.
 func formatStringType(t *openapi3.Schema) string {
 	var format string

--- a/oxide/types.go
+++ b/oxide/types.go
@@ -404,7 +404,7 @@ type BgpConfigResultsPage struct {
 // - Exports
 type BgpExported struct {
 	// Exports is exported routes indexed by peer address.
-	Exports Ipv4Net `json:"exports,omitempty" yaml:"exports,omitempty"`
+	Exports map[string][]Ipv4Net `json:"exports,omitempty" yaml:"exports,omitempty"`
 }
 
 // BgpImportedRouteIpv4 is a route imported from a BGP peer.
@@ -4393,7 +4393,7 @@ type Silo struct {
 	// MappedFleetRoles is mapping of which Fleet roles are conferred by each Silo role
 	//
 	// The default is that no Fleet roles are conferred by any Silo roles unless there's a corresponding entry in this map.
-	MappedFleetRoles FleetRole `json:"mapped_fleet_roles,omitempty" yaml:"mapped_fleet_roles,omitempty"`
+	MappedFleetRoles map[string][]FleetRole `json:"mapped_fleet_roles,omitempty" yaml:"mapped_fleet_roles,omitempty"`
 	// Name is unique, mutable, user-controlled identifier for each resource
 	Name Name `json:"name,omitempty" yaml:"name,omitempty"`
 	// TimeCreated is timestamp when this resource was created
@@ -4423,7 +4423,7 @@ type SiloCreate struct {
 	// MappedFleetRoles is mapping of which Fleet roles are conferred by each Silo role
 	//
 	// The default is that no Fleet roles are conferred by any Silo roles unless there's a corresponding entry in this map.
-	MappedFleetRoles FleetRole `json:"mapped_fleet_roles,omitempty" yaml:"mapped_fleet_roles,omitempty"`
+	MappedFleetRoles map[string][]FleetRole `json:"mapped_fleet_roles,omitempty" yaml:"mapped_fleet_roles,omitempty"`
 	// Name is names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID, but they may contain a UUID. They can be at most 63 characters long.
 	Name Name `json:"name,omitempty" yaml:"name,omitempty"`
 	// Quotas is limits the amount of provisionable CPU, memory, and storage in the Silo. CPU and memory are only consumed by running instances, while storage is consumed by any disk or snapshot. A value of 0 means that resource is *not* provisionable.

--- a/oxide/utils.go
+++ b/oxide/utils.go
@@ -8,6 +8,11 @@ import (
 	"text/template"
 )
 
+// NewPointer returns a pointer to a given value.
+func NewPointer[T any](v T) *T {
+	return &v
+}
+
 // resolveRelative combines a url base with a relative path.
 func resolveRelative(basestr, relstr string) string {
 	u, _ := url.Parse(basestr)


### PR DESCRIPTION
Our OpenAPI spec defines maps in the following manner:

```json
"Silo": {
  "description": "View of a Silo\n\nA Silo is the highest level unit of isolation.",
  "type": "object",
  "properties": {
    "mapped_fleet_roles": {
      "description": "Mapping of which Fleet roles are conferred by each Silo role\n\nThe default is that no Fleet roles are conferred by any Silo roles unless there's a corresponding entry in this map.",
      "type": "object",
      "additionalProperties": {
        "type": "array",
        "items": {
          "$ref": "#/components/schemas/FleetRole"
        },
        "uniqueItems": true
      }
    }
  },
  "required": [
    "mapped_fleet_roles",
  ]
}
```

In this scenario this should be parsed into

```go
type Silo struct {
	// MappedFleetRoles is mapping of which Fleet roles are conferred by each Silo role
	//
	// The default is that no Fleet roles are conferred by any Silo roles unless there's a corresponding entry in this map.
	MappedFleetRoles map[string][SiloRole]FleetRole `json:"mapped_fleet_roles,omitempty" yaml:"mapped_fleet_roles,omitempty"`
}
```

But, our API spec makes no mention of `SiloRole`. To avoid making any hardcoded one-offs, we will be setting the map key to be a string. This should be changed once our OpenAPI spec mentions the key type
