### PR TITLE
Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ lint: tools ## Verifies `golangci-lint` passes.
 .PHONY: test
 test: ## Runs the go tests.
 	@ echo "+ Running Go tests..."
-	@ $(GO) test -v -tags "$(BUILDTAGS) cgo" ./...
+	@ $(GO) test -v -tags "$(BUILDTAGS)" ./...
 
 .PHONY: vet
 vet: ## Verifies `go vet` passes.

--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,6 @@ staticcheck: tools ## Verifies `staticcheck` passes.
 		exit 1; \
 	fi
 
-.PHONY: install
-install: ## Installs the executable or package.
-	@echo "+ $@"
-	$(GO) install -a -tags "$(BUILDTAGS)" ${GO_LDFLAGS} .
-
 .PHONY: tag
 tag: ## Create a new git tag to prepare to build a release.
 	git tag -sa $(VERSION) -m "$(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ help:
 # This way linting tools don't need to be downloaded/installed every time you
 # want to run the linters or generate the SDK.
 VERSION_DIR:=$(GOBIN)/versions
-VERSION_GOIMPORTS:=v0.24.0
+VERSION_GOIMPORTS:=v0.26.0
 VERSION_GOLANGCILINT:=v1.61.0
 VERSION_STATICCHECK:=2024.1.1
 VERSION_WHATSIT:=1f5eb3ea


### PR DESCRIPTION
A few small cleanups to the `Makefile`:

- Update the `goimports` tool to the latest version.
- We have no binaries for the `install` target to install, so calling it will fail:
    ```
    $ make install
    + install
    go install -a -tags ""  .
    no Go files in /Users/wfc/devel/oxide.d/oxide.go
    make: *** [install] Error 1
    ```
    Remove the obsolete target.

- We don't use CGO, remove it from our build tags on the `test` target.