### PR TITLE
Set integer fields as pointers

### DIFF
--- a/.changelog/v0.4.0.toml
+++ b/.changelog/v0.4.0.toml
@@ -1,6 +1,6 @@
 [[breaking]]
-title = ""
-description = ""
+title = "Integers as pointers"
+description = "All integers within the SDK's types are now `*int`. This is due to Go's handling of 0 as the empty value. This is specifically necessary when a field is an integer and also not required. [#XXX](https://github.com/oxidecomputer/oxide.go/pull/XXX)"
 
 [[features]]
 title = "Affinity and anti-affinity groups"

--- a/.changelog/v0.4.0.toml
+++ b/.changelog/v0.4.0.toml
@@ -1,6 +1,6 @@
 [[breaking]]
 title = "Integers as pointers"
-description = "All integers within the SDK's types are now `*int`. This is due to Go's handling of 0 as the empty value. This is specifically necessary when a field is an integer and also not required. [#XXX](https://github.com/oxidecomputer/oxide.go/pull/XXX)"
+description = "All integers within the SDK's types are now `*int`. This is due to Go's handling of 0 as the empty value. This is specifically necessary when a field is an integer and also not required. [#274](https://github.com/oxidecomputer/oxide.go/pull/274)"
 
 [[features]]
 title = "Affinity and anti-affinity groups"

--- a/internal/generate/paths.go
+++ b/internal/generate/paths.go
@@ -371,8 +371,8 @@ func buildPathOrQueryParams(paramType string, params map[string]*openapi3.Parame
 				pathParams = append(pathParams, fmt.Sprintf("%q: strconv.FormatBool(%s),", name, n))
 			case "*bool":
 				pathParams = append(pathParams, fmt.Sprintf("%q: strconv.FormatBool(*%s),", name, n))
-			case "int":
-				pathParams = append(pathParams, fmt.Sprintf("%q: strconv.Itoa(%s),", name, n))
+			case "*int":
+				pathParams = append(pathParams, fmt.Sprintf("%q: PointerIntToStr(%s),", name, n))
 			case "*time.Time":
 				pathParams = append(pathParams, fmt.Sprintf("%q: %s.Format(time.RFC3339),", name, n))
 			default:

--- a/internal/generate/templates/listall_method.tpl
+++ b/internal/generate/templates/listall_method.tpl
@@ -4,7 +4,7 @@
 	}{{end}}
 	var allPages {{.ResponseType}}
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.{{.WrappedFunction}}(ctx, params)
 		if err != nil {

--- a/internal/generate/test_utils/paths_output
+++ b/internal/generate/test_utils/paths_output
@@ -22,7 +22,7 @@ func (c *Client) IpPoolList(ctx context.Context, params IpPoolListParams, ) (*Ip
         map[string]string{ 
         }, 
         map[string]string{ 
-            "limit": strconv.Itoa(params.Limit),
+            "limit": PointerIntToStr(params.Limit),
             "page_token": params.PageToken,
             "sort_by": string(params.SortBy),
         },
@@ -67,7 +67,7 @@ func (c *Client) IpPoolListAllPages(ctx context.Context, params IpPoolListParams
 	}
 	var allPages []IpPool
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.IpPoolList(ctx, params)
 		if err != nil {

--- a/internal/generate/test_utils/paths_output_expected
+++ b/internal/generate/test_utils/paths_output_expected
@@ -22,7 +22,7 @@ func (c *Client) IpPoolList(ctx context.Context, params IpPoolListParams, ) (*Ip
         map[string]string{ 
         }, 
         map[string]string{ 
-            "limit": strconv.Itoa(params.Limit),
+            "limit": PointerIntToStr(params.Limit),
             "page_token": params.PageToken,
             "sort_by": string(params.SortBy),
         },
@@ -67,7 +67,7 @@ func (c *Client) IpPoolListAllPages(ctx context.Context, params IpPoolListParams
 	}
 	var allPages []IpPool
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.IpPoolList(ctx, params)
 		if err != nil {

--- a/internal/generate/types.go
+++ b/internal/generate/types.go
@@ -354,7 +354,6 @@ func writeTypes(f *os.File, typeCollection []TypeTemplate, typeValidationCollect
 			fmt.Fprint(f, " {\n")
 			for _, ft := range tt.Fields {
 				if ft.Description != "" {
-					// TODO: Double check about the "//"
 					fmt.Fprintf(f, "\t%s\n", splitDocString(ft.Description))
 				}
 				fmt.Fprintf(f, "\t%s %s %s\n", ft.Name, ft.Type, ft.SerializationInfo)
@@ -380,7 +379,7 @@ func writeTypes(f *os.File, typeCollection []TypeTemplate, typeValidationCollect
 			fmt.Fprintf(f, "v.HasRequiredStr(string(p.%s), \"%s\")\n", s, s)
 		}
 		for _, i := range vm.RequiredNums {
-			fmt.Fprintf(f, "v.HasRequiredNum(int(p.%s), \"%s\")\n", i, i)
+			fmt.Fprintf(f, "v.HasRequiredNum(p.%s, \"%s\")\n", i, i)
 		}
 		fmt.Fprintln(f, "if !v.IsValid() {")
 		// Unfortunately I have to craft the following line this way as I get

--- a/internal/generate/utils.go
+++ b/internal/generate/utils.go
@@ -139,7 +139,9 @@ func convertToValidGoType(property string, r *openapi3.SchemaRef) string {
 	if r.Value.Type.Is("string") {
 		schemaType = formatStringType(r.Value)
 	} else if r.Value.Type.Is("integer") {
-		schemaType = "int"
+		// It is necessary to use pointers for integer types as we need
+		// to differentiate between an empty value and a 0.
+		schemaType = "*int"
 	} else if r.Value.Type.Is("number") {
 		schemaType = "float64"
 	} else if r.Value.Type.Is("boolean") {

--- a/oxide/paths.go
+++ b/oxide/paths.go
@@ -69,7 +69,7 @@ func (c *Client) AffinityGroupList(ctx context.Context, params AffinityGroupList
 		resolveRelative(c.host, "/v1/affinity-groups"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -115,7 +115,7 @@ func (c *Client) AffinityGroupListAllPages(ctx context.Context, params AffinityG
 	}
 	var allPages []AffinityGroup
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.AffinityGroupList(ctx, params)
 		if err != nil {
@@ -339,7 +339,7 @@ func (c *Client) AffinityGroupMemberList(ctx context.Context, params AffinityGro
 			"affinity_group": string(params.AffinityGroup),
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -385,7 +385,7 @@ func (c *Client) AffinityGroupMemberListAllPages(ctx context.Context, params Aff
 	}
 	var allPages []AffinityGroupMember
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.AffinityGroupMemberList(ctx, params)
 		if err != nil {
@@ -552,7 +552,7 @@ func (c *Client) AntiAffinityGroupList(ctx context.Context, params AntiAffinityG
 		resolveRelative(c.host, "/v1/anti-affinity-groups"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -598,7 +598,7 @@ func (c *Client) AntiAffinityGroupListAllPages(ctx context.Context, params AntiA
 	}
 	var allPages []AntiAffinityGroup
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.AntiAffinityGroupList(ctx, params)
 		if err != nil {
@@ -822,7 +822,7 @@ func (c *Client) AntiAffinityGroupMemberList(ctx context.Context, params AntiAff
 			"anti_affinity_group": string(params.AntiAffinityGroup),
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -868,7 +868,7 @@ func (c *Client) AntiAffinityGroupMemberListAllPages(ctx context.Context, params
 	}
 	var allPages []AntiAffinityGroupMember
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.AntiAffinityGroupMemberList(ctx, params)
 		if err != nil {
@@ -1037,7 +1037,7 @@ func (c *Client) CertificateList(ctx context.Context, params CertificateListPara
 		resolveRelative(c.host, "/v1/certificates"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -1084,7 +1084,7 @@ func (c *Client) CertificateListAllPages(ctx context.Context, params Certificate
 	}
 	var allPages []Certificate
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.CertificateList(ctx, params)
 		if err != nil {
@@ -1249,7 +1249,7 @@ func (c *Client) DiskList(ctx context.Context, params DiskListParams) (*DiskResu
 		resolveRelative(c.host, "/v1/disks"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -1295,7 +1295,7 @@ func (c *Client) DiskListAllPages(ctx context.Context, params DiskListParams) ([
 	}
 	var allPages []Disk
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.DiskList(ctx, params)
 		if err != nil {
@@ -1629,7 +1629,7 @@ func (c *Client) DiskMetricsList(ctx context.Context, params DiskMetricsListPara
 		},
 		map[string]string{
 			"end_time":   params.EndTime.Format(time.RFC3339),
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"order":      string(params.Order),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
@@ -1676,7 +1676,7 @@ func (c *Client) DiskMetricsListAllPages(ctx context.Context, params DiskMetrics
 	}
 	var allPages []Measurement
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.DiskMetricsList(ctx, params)
 		if err != nil {
@@ -1707,7 +1707,7 @@ func (c *Client) FloatingIpList(ctx context.Context, params FloatingIpListParams
 		resolveRelative(c.host, "/v1/floating-ips"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -1753,7 +1753,7 @@ func (c *Client) FloatingIpListAllPages(ctx context.Context, params FloatingIpLi
 	}
 	var allPages []FloatingIp
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.FloatingIpList(ctx, params)
 		if err != nil {
@@ -2078,7 +2078,7 @@ func (c *Client) GroupList(ctx context.Context, params GroupListParams) (*GroupR
 		resolveRelative(c.host, "/v1/groups"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -2123,7 +2123,7 @@ func (c *Client) GroupListAllPages(ctx context.Context, params GroupListParams) 
 	}
 	var allPages []Group
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.GroupList(ctx, params)
 		if err != nil {
@@ -2202,7 +2202,7 @@ func (c *Client) ImageList(ctx context.Context, params ImageListParams) (*ImageR
 		resolveRelative(c.host, "/v1/images"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -2250,7 +2250,7 @@ func (c *Client) ImageListAllPages(ctx context.Context, params ImageListParams) 
 	}
 	var allPages []Image
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.ImageList(ctx, params)
 		if err != nil {
@@ -2520,7 +2520,7 @@ func (c *Client) InstanceList(ctx context.Context, params InstanceListParams) (*
 		resolveRelative(c.host, "/v1/instances"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -2566,7 +2566,7 @@ func (c *Client) InstanceListAllPages(ctx context.Context, params InstanceListPa
 	}
 	var allPages []Instance
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.InstanceList(ctx, params)
 		if err != nil {
@@ -2790,7 +2790,7 @@ func (c *Client) InstanceDiskList(ctx context.Context, params InstanceDiskListPa
 			"instance": string(params.Instance),
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -2836,7 +2836,7 @@ func (c *Client) InstanceDiskListAllPages(ctx context.Context, params InstanceDi
 	}
 	var allPages []Disk
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.InstanceDiskList(ctx, params)
 		if err != nil {
@@ -3162,9 +3162,9 @@ func (c *Client) InstanceSerialConsole(ctx context.Context, params InstanceSeria
 			"instance": string(params.Instance),
 		},
 		map[string]string{
-			"from_start":  strconv.Itoa(params.FromStart),
-			"max_bytes":   strconv.Itoa(params.MaxBytes),
-			"most_recent": strconv.Itoa(params.MostRecent),
+			"from_start":  PointerIntToStr(params.FromStart),
+			"max_bytes":   PointerIntToStr(params.MaxBytes),
+			"most_recent": PointerIntToStr(params.MostRecent),
 			"project":     string(params.Project),
 		},
 	)
@@ -3213,7 +3213,7 @@ func (c *Client) InstanceSerialConsoleStream(ctx context.Context, params Instanc
 			"instance": string(params.Instance),
 		},
 		map[string]string{
-			"most_recent": strconv.Itoa(params.MostRecent),
+			"most_recent": PointerIntToStr(params.MostRecent),
 			"project":     string(params.Project),
 		},
 	)
@@ -3255,7 +3255,7 @@ func (c *Client) InstanceSshPublicKeyList(ctx context.Context, params InstanceSs
 			"instance": string(params.Instance),
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -3303,7 +3303,7 @@ func (c *Client) InstanceSshPublicKeyListAllPages(ctx context.Context, params In
 	}
 	var allPages []SshKey
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.InstanceSshPublicKeyList(ctx, params)
 		if err != nil {
@@ -3431,7 +3431,7 @@ func (c *Client) InternetGatewayIpAddressList(ctx context.Context, params Intern
 		map[string]string{},
 		map[string]string{
 			"gateway":    string(params.Gateway),
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -3478,7 +3478,7 @@ func (c *Client) InternetGatewayIpAddressListAllPages(ctx context.Context, param
 	}
 	var allPages []InternetGatewayIpAddress
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.InternetGatewayIpAddressList(ctx, params)
 		if err != nil {
@@ -3604,7 +3604,7 @@ func (c *Client) InternetGatewayIpPoolList(ctx context.Context, params InternetG
 		map[string]string{},
 		map[string]string{
 			"gateway":    string(params.Gateway),
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -3651,7 +3651,7 @@ func (c *Client) InternetGatewayIpPoolListAllPages(ctx context.Context, params I
 	}
 	var allPages []InternetGatewayIpPool
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.InternetGatewayIpPoolList(ctx, params)
 		if err != nil {
@@ -3776,7 +3776,7 @@ func (c *Client) InternetGatewayList(ctx context.Context, params InternetGateway
 		resolveRelative(c.host, "/v1/internet-gateways"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -3823,7 +3823,7 @@ func (c *Client) InternetGatewayListAllPages(ctx context.Context, params Interne
 	}
 	var allPages []InternetGateway
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.InternetGatewayList(ctx, params)
 		if err != nil {
@@ -3995,7 +3995,7 @@ func (c *Client) ProjectIpPoolList(ctx context.Context, params ProjectIpPoolList
 		resolveRelative(c.host, "/v1/ip-pools"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -4040,7 +4040,7 @@ func (c *Client) ProjectIpPoolListAllPages(ctx context.Context, params ProjectIp
 	}
 	var allPages []SiloIpPool
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.ProjectIpPoolList(ctx, params)
 		if err != nil {
@@ -4199,7 +4199,7 @@ func (c *Client) CurrentUserGroups(ctx context.Context, params CurrentUserGroups
 		resolveRelative(c.host, "/v1/me/groups"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -4244,7 +4244,7 @@ func (c *Client) CurrentUserGroupsAllPages(ctx context.Context, params CurrentUs
 	}
 	var allPages []Group
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.CurrentUserGroups(ctx, params)
 		if err != nil {
@@ -4276,7 +4276,7 @@ func (c *Client) CurrentUserSshKeyList(ctx context.Context, params CurrentUserSs
 		resolveRelative(c.host, "/v1/me/ssh-keys"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -4322,7 +4322,7 @@ func (c *Client) CurrentUserSshKeyListAllPages(ctx context.Context, params Curre
 	}
 	var allPages []SshKey
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.CurrentUserSshKeyList(ctx, params)
 		if err != nil {
@@ -4491,7 +4491,7 @@ func (c *Client) SiloMetric(ctx context.Context, params SiloMetricParams) (*Meas
 		},
 		map[string]string{
 			"end_time":   params.EndTime.Format(time.RFC3339),
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"order":      string(params.Order),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
@@ -4539,7 +4539,7 @@ func (c *Client) SiloMetricAllPages(ctx context.Context, params SiloMetricParams
 	}
 	var allPages []Measurement
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SiloMetric(ctx, params)
 		if err != nil {
@@ -4571,7 +4571,7 @@ func (c *Client) InstanceNetworkInterfaceList(ctx context.Context, params Instan
 		map[string]string{},
 		map[string]string{
 			"instance":   string(params.Instance),
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -4617,7 +4617,7 @@ func (c *Client) InstanceNetworkInterfaceListAllPages(ctx context.Context, param
 	}
 	var allPages []InstanceNetworkInterface
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.InstanceNetworkInterfaceList(ctx, params)
 		if err != nil {
@@ -4979,7 +4979,7 @@ func (c *Client) ProjectList(ctx context.Context, params ProjectListParams) (*Pr
 		resolveRelative(c.host, "/v1/projects"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -5024,7 +5024,7 @@ func (c *Client) ProjectListAllPages(ctx context.Context, params ProjectListPara
 	}
 	var allPages []Project
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.ProjectList(ctx, params)
 		if err != nil {
@@ -5336,7 +5336,7 @@ func (c *Client) SnapshotList(ctx context.Context, params SnapshotListParams) (*
 		resolveRelative(c.host, "/v1/snapshots"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -5382,7 +5382,7 @@ func (c *Client) SnapshotListAllPages(ctx context.Context, params SnapshotListPa
 	}
 	var allPages []Snapshot
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SnapshotList(ctx, params)
 		if err != nil {
@@ -5551,7 +5551,7 @@ func (c *Client) PhysicalDiskList(ctx context.Context, params PhysicalDiskListPa
 		resolveRelative(c.host, "/v1/system/hardware/disks"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -5596,7 +5596,7 @@ func (c *Client) PhysicalDiskListAllPages(ctx context.Context, params PhysicalDi
 	}
 	var allPages []PhysicalDisk
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.PhysicalDiskList(ctx, params)
 		if err != nil {
@@ -5677,7 +5677,7 @@ func (c *Client) NetworkingSwitchPortLldpNeighbors(ctx context.Context, params N
 			"switch_location": string(params.SwitchLocation),
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -5722,7 +5722,7 @@ func (c *Client) NetworkingSwitchPortLldpNeighborsAllPages(ctx context.Context, 
 	}
 	var allPages []LldpNeighbor
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.NetworkingSwitchPortLldpNeighbors(ctx, params)
 		if err != nil {
@@ -5753,7 +5753,7 @@ func (c *Client) RackList(ctx context.Context, params RackListParams) (*RackResu
 		resolveRelative(c.host, "/v1/system/hardware/racks"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -5798,7 +5798,7 @@ func (c *Client) RackListAllPages(ctx context.Context, params RackListParams) ([
 	}
 	var allPages []Rack
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.RackList(ctx, params)
 		if err != nil {
@@ -5875,7 +5875,7 @@ func (c *Client) SledList(ctx context.Context, params SledListParams) (*SledResu
 		resolveRelative(c.host, "/v1/system/hardware/sleds"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -5920,7 +5920,7 @@ func (c *Client) SledListAllPages(ctx context.Context, params SledListParams) ([
 	}
 	var allPages []Sled
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SledList(ctx, params)
 		if err != nil {
@@ -6001,7 +6001,7 @@ func (c *Client) SledListUninitialized(ctx context.Context, params SledListUnini
 		resolveRelative(c.host, "/v1/system/hardware/sleds-uninitialized"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 		},
 	)
@@ -6045,7 +6045,7 @@ func (c *Client) SledListUninitializedAllPages(ctx context.Context, params SledL
 	}
 	var allPages []UninitializedSled
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SledListUninitialized(ctx, params)
 		if err != nil {
@@ -6124,7 +6124,7 @@ func (c *Client) SledPhysicalDiskList(ctx context.Context, params SledPhysicalDi
 			"sled_id": params.SledId,
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -6169,7 +6169,7 @@ func (c *Client) SledPhysicalDiskListAllPages(ctx context.Context, params SledPh
 	}
 	var allPages []PhysicalDisk
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SledPhysicalDiskList(ctx, params)
 		if err != nil {
@@ -6202,7 +6202,7 @@ func (c *Client) SledInstanceList(ctx context.Context, params SledInstanceListPa
 			"sled_id": params.SledId,
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -6247,7 +6247,7 @@ func (c *Client) SledInstanceListAllPages(ctx context.Context, params SledInstan
 	}
 	var allPages []SledInstance
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SledInstanceList(ctx, params)
 		if err != nil {
@@ -6330,7 +6330,7 @@ func (c *Client) NetworkingSwitchPortList(ctx context.Context, params Networking
 		resolveRelative(c.host, "/v1/system/hardware/switch-port"),
 		map[string]string{},
 		map[string]string{
-			"limit":          strconv.Itoa(params.Limit),
+			"limit":          PointerIntToStr(params.Limit),
 			"page_token":     params.PageToken,
 			"sort_by":        string(params.SortBy),
 			"switch_port_id": params.SwitchPortId,
@@ -6376,7 +6376,7 @@ func (c *Client) NetworkingSwitchPortListAllPages(ctx context.Context, params Ne
 	}
 	var allPages []SwitchPort
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.NetworkingSwitchPortList(ctx, params)
 		if err != nil {
@@ -6631,7 +6631,7 @@ func (c *Client) SwitchList(ctx context.Context, params SwitchListParams) (*Swit
 		resolveRelative(c.host, "/v1/system/hardware/switches"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -6676,7 +6676,7 @@ func (c *Client) SwitchListAllPages(ctx context.Context, params SwitchListParams
 	}
 	var allPages []Switch
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SwitchList(ctx, params)
 		if err != nil {
@@ -6753,7 +6753,7 @@ func (c *Client) SiloIdentityProviderList(ctx context.Context, params SiloIdenti
 		resolveRelative(c.host, "/v1/system/identity-providers"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"silo":       string(params.Silo),
 			"sort_by":    string(params.SortBy),
@@ -6799,7 +6799,7 @@ func (c *Client) SiloIdentityProviderListAllPages(ctx context.Context, params Si
 	}
 	var allPages []IdentityProvider
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SiloIdentityProviderList(ctx, params)
 		if err != nil {
@@ -7065,7 +7065,7 @@ func (c *Client) IpPoolList(ctx context.Context, params IpPoolListParams) (*IpPo
 		resolveRelative(c.host, "/v1/system/ip-pools"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -7110,7 +7110,7 @@ func (c *Client) IpPoolListAllPages(ctx context.Context, params IpPoolListParams
 	}
 	var allPages []IpPool
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.IpPoolList(ctx, params)
 		if err != nil {
@@ -7233,7 +7233,7 @@ func (c *Client) IpPoolServiceRangeList(ctx context.Context, params IpPoolServic
 		resolveRelative(c.host, "/v1/system/ip-pools-service/ranges"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 		},
 	)
@@ -7278,7 +7278,7 @@ func (c *Client) IpPoolServiceRangeListAllPages(ctx context.Context, params IpPo
 	}
 	var allPages []IpPoolRange
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.IpPoolServiceRangeList(ctx, params)
 		if err != nil {
@@ -7535,7 +7535,7 @@ func (c *Client) IpPoolRangeList(ctx context.Context, params IpPoolRangeListPara
 			"pool": string(params.Pool),
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 		},
 	)
@@ -7580,7 +7580,7 @@ func (c *Client) IpPoolRangeListAllPages(ctx context.Context, params IpPoolRange
 	}
 	var allPages []IpPoolRange
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.IpPoolRangeList(ctx, params)
 		if err != nil {
@@ -7707,7 +7707,7 @@ func (c *Client) IpPoolSiloList(ctx context.Context, params IpPoolSiloListParams
 			"pool": string(params.Pool),
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -7752,7 +7752,7 @@ func (c *Client) IpPoolSiloListAllPages(ctx context.Context, params IpPoolSiloLi
 	}
 	var allPages []IpPoolSiloLink
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.IpPoolSiloList(ctx, params)
 		if err != nil {
@@ -7980,7 +7980,7 @@ func (c *Client) SystemMetric(ctx context.Context, params SystemMetricParams) (*
 		},
 		map[string]string{
 			"end_time":   params.EndTime.Format(time.RFC3339),
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"order":      string(params.Order),
 			"page_token": params.PageToken,
 			"silo":       string(params.Silo),
@@ -8028,7 +8028,7 @@ func (c *Client) SystemMetricAllPages(ctx context.Context, params SystemMetricPa
 	}
 	var allPages []Measurement
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SystemMetric(ctx, params)
 		if err != nil {
@@ -8059,7 +8059,7 @@ func (c *Client) NetworkingAddressLotList(ctx context.Context, params Networking
 		resolveRelative(c.host, "/v1/system/networking/address-lot"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -8104,7 +8104,7 @@ func (c *Client) NetworkingAddressLotListAllPages(ctx context.Context, params Ne
 	}
 	var allPages []AddressLot
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.NetworkingAddressLotList(ctx, params)
 		if err != nil {
@@ -8222,7 +8222,7 @@ func (c *Client) NetworkingAddressLotBlockList(ctx context.Context, params Netwo
 			"address_lot": string(params.AddressLot),
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -8267,7 +8267,7 @@ func (c *Client) NetworkingAddressLotBlockListAllPages(ctx context.Context, para
 	}
 	var allPages []AddressLotBlock
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.NetworkingAddressLotBlockList(ctx, params)
 		if err != nil {
@@ -8508,7 +8508,7 @@ func (c *Client) NetworkingBgpConfigList(ctx context.Context, params NetworkingB
 		resolveRelative(c.host, "/v1/system/networking/bgp"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -8553,7 +8553,7 @@ func (c *Client) NetworkingBgpConfigListAllPages(ctx context.Context, params Net
 	}
 	var allPages []BgpConfig
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.NetworkingBgpConfigList(ctx, params)
 		if err != nil {
@@ -8669,7 +8669,7 @@ func (c *Client) NetworkingBgpAnnounceSetList(ctx context.Context, params Networ
 		resolveRelative(c.host, "/v1/system/networking/bgp-announce-set"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -8890,7 +8890,7 @@ func (c *Client) NetworkingBgpMessageHistory(ctx context.Context, params Network
 		resolveRelative(c.host, "/v1/system/networking/bgp-message-history"),
 		map[string]string{},
 		map[string]string{
-			"asn": strconv.Itoa(params.Asn),
+			"asn": PointerIntToStr(params.Asn),
 		},
 	)
 	if err != nil {
@@ -8936,7 +8936,7 @@ func (c *Client) NetworkingBgpImportedRoutesIpv4(ctx context.Context, params Net
 		resolveRelative(c.host, "/v1/system/networking/bgp-routes-ipv4"),
 		map[string]string{},
 		map[string]string{
-			"asn": strconv.Itoa(params.Asn),
+			"asn": PointerIntToStr(params.Asn),
 		},
 	)
 	if err != nil {
@@ -9025,7 +9025,7 @@ func (c *Client) NetworkingLoopbackAddressList(ctx context.Context, params Netwo
 		resolveRelative(c.host, "/v1/system/networking/loopback-address"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -9070,7 +9070,7 @@ func (c *Client) NetworkingLoopbackAddressListAllPages(ctx context.Context, para
 	}
 	var allPages []LoopbackAddress
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.NetworkingLoopbackAddressList(ctx, params)
 		if err != nil {
@@ -9150,7 +9150,7 @@ func (c *Client) NetworkingLoopbackAddressDelete(ctx context.Context, params Net
 		map[string]string{
 			"address":         params.Address,
 			"rack_id":         params.RackId,
-			"subnet_mask":     strconv.Itoa(params.SubnetMask),
+			"subnet_mask":     PointerIntToStr(params.SubnetMask),
 			"switch_location": string(params.SwitchLocation),
 		},
 		map[string]string{},
@@ -9189,7 +9189,7 @@ func (c *Client) NetworkingSwitchPortSettingsList(ctx context.Context, params Ne
 		resolveRelative(c.host, "/v1/system/networking/switch-port-settings"),
 		map[string]string{},
 		map[string]string{
-			"limit":         strconv.Itoa(params.Limit),
+			"limit":         PointerIntToStr(params.Limit),
 			"page_token":    params.PageToken,
 			"port_settings": string(params.PortSettings),
 			"sort_by":       string(params.SortBy),
@@ -9235,7 +9235,7 @@ func (c *Client) NetworkingSwitchPortSettingsListAllPages(ctx context.Context, p
 	}
 	var allPages []SwitchPortSettings
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.NetworkingSwitchPortSettingsList(ctx, params)
 		if err != nil {
@@ -9488,7 +9488,7 @@ func (c *Client) RoleList(ctx context.Context, params RoleListParams) (*RoleResu
 		resolveRelative(c.host, "/v1/system/roles"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 		},
 	)
@@ -9532,7 +9532,7 @@ func (c *Client) RoleListAllPages(ctx context.Context, params RoleListParams) ([
 	}
 	var allPages []Role
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.RoleList(ctx, params)
 		if err != nil {
@@ -9609,7 +9609,7 @@ func (c *Client) SystemQuotasList(ctx context.Context, params SystemQuotasListPa
 		resolveRelative(c.host, "/v1/system/silo-quotas"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -9654,7 +9654,7 @@ func (c *Client) SystemQuotasListAllPages(ctx context.Context, params SystemQuot
 	}
 	var allPages []SiloQuotas
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SystemQuotasList(ctx, params)
 		if err != nil {
@@ -9686,7 +9686,7 @@ func (c *Client) SiloList(ctx context.Context, params SiloListParams) (*SiloResu
 		resolveRelative(c.host, "/v1/system/silos"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -9732,7 +9732,7 @@ func (c *Client) SiloListAllPages(ctx context.Context, params SiloListParams) ([
 	}
 	var allPages []Silo
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SiloList(ctx, params)
 		if err != nil {
@@ -9900,7 +9900,7 @@ func (c *Client) SiloIpPoolList(ctx context.Context, params SiloIpPoolListParams
 			"silo": string(params.Silo),
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -9947,7 +9947,7 @@ func (c *Client) SiloIpPoolListAllPages(ctx context.Context, params SiloIpPoolLi
 	}
 	var allPages []SiloIpPool
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SiloIpPoolList(ctx, params)
 		if err != nil {
@@ -10226,7 +10226,7 @@ func (c *Client) SystemTimeseriesSchemaList(ctx context.Context, params SystemTi
 		resolveRelative(c.host, "/v1/system/timeseries/schemas"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 		},
 	)
@@ -10270,7 +10270,7 @@ func (c *Client) SystemTimeseriesSchemaListAllPages(ctx context.Context, params 
 	}
 	var allPages []TimeseriesSchema
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SystemTimeseriesSchemaList(ctx, params)
 		if err != nil {
@@ -10301,7 +10301,7 @@ func (c *Client) SiloUserList(ctx context.Context, params SiloUserListParams) (*
 		resolveRelative(c.host, "/v1/system/users"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"silo":       string(params.Silo),
 			"sort_by":    string(params.SortBy),
@@ -10347,7 +10347,7 @@ func (c *Client) SiloUserListAllPages(ctx context.Context, params SiloUserListPa
 	}
 	var allPages []User
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SiloUserList(ctx, params)
 		if err != nil {
@@ -10378,7 +10378,7 @@ func (c *Client) UserBuiltinList(ctx context.Context, params UserBuiltinListPara
 		resolveRelative(c.host, "/v1/system/users-builtin"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -10423,7 +10423,7 @@ func (c *Client) UserBuiltinListAllPages(ctx context.Context, params UserBuiltin
 	}
 	var allPages []UserBuiltin
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.UserBuiltinList(ctx, params)
 		if err != nil {
@@ -10548,7 +10548,7 @@ func (c *Client) SiloUtilizationList(ctx context.Context, params SiloUtilization
 		resolveRelative(c.host, "/v1/system/utilization/silos"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -10593,7 +10593,7 @@ func (c *Client) SiloUtilizationListAllPages(ctx context.Context, params SiloUti
 	}
 	var allPages []SiloUtilization
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.SiloUtilizationList(ctx, params)
 		if err != nil {
@@ -10671,7 +10671,7 @@ func (c *Client) UserList(ctx context.Context, params UserListParams) (*UserResu
 		map[string]string{},
 		map[string]string{
 			"group":      params.Group,
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
 		},
@@ -10716,7 +10716,7 @@ func (c *Client) UserListAllPages(ctx context.Context, params UserListParams) ([
 	}
 	var allPages []User
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.UserList(ctx, params)
 		if err != nil {
@@ -10899,7 +10899,7 @@ func (c *Client) VpcRouterRouteList(ctx context.Context, params VpcRouterRouteLi
 		resolveRelative(c.host, "/v1/vpc-router-routes"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"router":     string(params.Router),
@@ -10948,7 +10948,7 @@ func (c *Client) VpcRouterRouteListAllPages(ctx context.Context, params VpcRoute
 	}
 	var allPages []RouterRoute
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.VpcRouterRouteList(ctx, params)
 		if err != nil {
@@ -11178,7 +11178,7 @@ func (c *Client) VpcRouterList(ctx context.Context, params VpcRouterListParams) 
 		resolveRelative(c.host, "/v1/vpc-routers"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -11225,7 +11225,7 @@ func (c *Client) VpcRouterListAllPages(ctx context.Context, params VpcRouterList
 	}
 	var allPages []VpcRouter
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.VpcRouterList(ctx, params)
 		if err != nil {
@@ -11451,7 +11451,7 @@ func (c *Client) VpcSubnetList(ctx context.Context, params VpcSubnetListParams) 
 		resolveRelative(c.host, "/v1/vpc-subnets"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -11498,7 +11498,7 @@ func (c *Client) VpcSubnetListAllPages(ctx context.Context, params VpcSubnetList
 	}
 	var allPages []VpcSubnet
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.VpcSubnetList(ctx, params)
 		if err != nil {
@@ -11726,7 +11726,7 @@ func (c *Client) VpcSubnetListNetworkInterfaces(ctx context.Context, params VpcS
 			"subnet": string(params.Subnet),
 		},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -11773,7 +11773,7 @@ func (c *Client) VpcSubnetListNetworkInterfacesAllPages(ctx context.Context, par
 	}
 	var allPages []InstanceNetworkInterface
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.VpcSubnetListNetworkInterfaces(ctx, params)
 		if err != nil {
@@ -11804,7 +11804,7 @@ func (c *Client) VpcList(ctx context.Context, params VpcListParams) (*VpcResults
 		resolveRelative(c.host, "/v1/vpcs"),
 		map[string]string{},
 		map[string]string{
-			"limit":      strconv.Itoa(params.Limit),
+			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
 			"sort_by":    string(params.SortBy),
@@ -11850,7 +11850,7 @@ func (c *Client) VpcListAllPages(ctx context.Context, params VpcListParams) ([]V
 	}
 	var allPages []Vpc
 	params.PageToken = ""
-	params.Limit = 100
+	params.Limit = NewPointer(100)
 	for {
 		page, err := c.VpcList(ctx, params)
 		if err != nil {

--- a/oxide/types.go
+++ b/oxide/types.go
@@ -23,7 +23,7 @@ type Address struct {
 	// AddressLot is the address lot this address is drawn from.
 	AddressLot NameOrId `json:"address_lot,omitempty" yaml:"address_lot,omitempty"`
 	// VlanId is optional VLAN ID for this address
-	VlanId int `json:"vlan_id,omitempty" yaml:"vlan_id,omitempty"`
+	VlanId *int `json:"vlan_id,omitempty" yaml:"vlan_id,omitempty"`
 }
 
 // AddressConfig is a set of addresses associated with a port configuration.
@@ -427,7 +427,7 @@ type AuthzScope string
 // - Serial
 type Baseboard struct {
 	Part     string `json:"part,omitempty" yaml:"part,omitempty"`
-	Revision int    `json:"revision,omitempty" yaml:"revision,omitempty"`
+	Revision *int   `json:"revision,omitempty" yaml:"revision,omitempty"`
 	Serial   string `json:"serial,omitempty" yaml:"serial,omitempty"`
 }
 
@@ -457,7 +457,7 @@ type BfdSessionDisable struct {
 type BfdSessionEnable struct {
 	// DetectionThreshold is the negotiated Control packet transmission interval, multiplied by this variable, will
 	// be the Detection Time for this session (as seen by the remote system)
-	DetectionThreshold int `json:"detection_threshold,omitempty" yaml:"detection_threshold,omitempty"`
+	DetectionThreshold *int `json:"detection_threshold,omitempty" yaml:"detection_threshold,omitempty"`
 	// Local is address the Oxide switch will listen on for BFD traffic. If `None` then the unspecified address (0.0.0.0
 	// or ::) is used.
 	Local string `json:"local,omitempty" yaml:"local,omitempty"`
@@ -467,7 +467,7 @@ type BfdSessionEnable struct {
 	Remote string `json:"remote,omitempty" yaml:"remote,omitempty"`
 	// RequiredRx is the minimum interval, in microseconds, between received BFD Control packets that this system
 	// requires
-	RequiredRx int `json:"required_rx,omitempty" yaml:"required_rx,omitempty"`
+	RequiredRx *int `json:"required_rx,omitempty" yaml:"required_rx,omitempty"`
 	// Switch is the switch to enable this session on. Must be `switch0` or `switch1`.
 	Switch Name `json:"switch,omitempty" yaml:"switch,omitempty"`
 }
@@ -485,12 +485,12 @@ type BfdState string
 // - State
 // - Switch
 type BfdStatus struct {
-	DetectionThreshold int    `json:"detection_threshold,omitempty" yaml:"detection_threshold,omitempty"`
+	DetectionThreshold *int   `json:"detection_threshold,omitempty" yaml:"detection_threshold,omitempty"`
 	Local              string `json:"local,omitempty" yaml:"local,omitempty"`
 	// Mode is bFD connection mode.
 	Mode       BfdMode  `json:"mode,omitempty" yaml:"mode,omitempty"`
 	Peer       string   `json:"peer,omitempty" yaml:"peer,omitempty"`
-	RequiredRx int      `json:"required_rx,omitempty" yaml:"required_rx,omitempty"`
+	RequiredRx *int     `json:"required_rx,omitempty" yaml:"required_rx,omitempty"`
 	State      BfdState `json:"state,omitempty" yaml:"state,omitempty"`
 	// Switch is names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase
 	// ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID, but they may contain a UUID. They
@@ -574,7 +574,7 @@ type BgpAnnouncementCreate struct {
 // - TimeModified
 type BgpConfig struct {
 	// Asn is the autonomous system number of this BGP configuration.
-	Asn int `json:"asn,omitempty" yaml:"asn,omitempty"`
+	Asn *int `json:"asn,omitempty" yaml:"asn,omitempty"`
 	// Description is human-readable free-form text about a resource
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// Id is unique, immutable, system-controlled identifier for each resource
@@ -599,7 +599,7 @@ type BgpConfig struct {
 // - Name
 type BgpConfigCreate struct {
 	// Asn is the autonomous system number of this BGP configuration.
-	Asn              int      `json:"asn,omitempty" yaml:"asn,omitempty"`
+	Asn              *int     `json:"asn,omitempty" yaml:"asn,omitempty"`
 	BgpAnnounceSetId NameOrId `json:"bgp_announce_set_id,omitempty" yaml:"bgp_announce_set_id,omitempty"`
 	Description      string   `json:"description,omitempty" yaml:"description,omitempty"`
 	// Name is names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase
@@ -639,7 +639,7 @@ type BgpExported struct {
 // - Switch
 type BgpImportedRouteIpv4 struct {
 	// Id is bGP identifier of the originating router.
-	Id int `json:"id,omitempty" yaml:"id,omitempty"`
+	Id *int `json:"id,omitempty" yaml:"id,omitempty"`
 	// Nexthop is the nexthop the prefix is reachable through.
 	Nexthop string `json:"nexthop,omitempty" yaml:"nexthop,omitempty"`
 	// Prefix is the destination network prefix.
@@ -680,33 +680,33 @@ type BgpPeer struct {
 	// Communities is include the provided communities in updates sent to the peer.
 	Communities []string `json:"communities,omitempty" yaml:"communities,omitempty"`
 	// ConnectRetry is how long to to wait between TCP connection retries (seconds).
-	ConnectRetry int `json:"connect_retry,omitempty" yaml:"connect_retry,omitempty"`
+	ConnectRetry *int `json:"connect_retry,omitempty" yaml:"connect_retry,omitempty"`
 	// DelayOpen is how long to delay sending an open request after establishing a TCP session (seconds).
-	DelayOpen int `json:"delay_open,omitempty" yaml:"delay_open,omitempty"`
+	DelayOpen *int `json:"delay_open,omitempty" yaml:"delay_open,omitempty"`
 	// EnforceFirstAs is enforce that the first AS in paths received from this peer is the peer's AS.
 	EnforceFirstAs *bool `json:"enforce_first_as,omitempty" yaml:"enforce_first_as,omitempty"`
 	// HoldTime is how long to hold peer connections between keepalives (seconds).
-	HoldTime int `json:"hold_time,omitempty" yaml:"hold_time,omitempty"`
+	HoldTime *int `json:"hold_time,omitempty" yaml:"hold_time,omitempty"`
 	// IdleHoldTime is how long to hold a peer in idle before attempting a new session (seconds).
-	IdleHoldTime int `json:"idle_hold_time,omitempty" yaml:"idle_hold_time,omitempty"`
+	IdleHoldTime *int `json:"idle_hold_time,omitempty" yaml:"idle_hold_time,omitempty"`
 	// InterfaceName is the name of interface to peer on. This is relative to the port configuration this BGP
 	// peer configuration is a part of. For example this value could be phy0 to refer to a primary physical interface.
 	// Or it could be vlan47 to refer to a VLAN interface.
 	InterfaceName string `json:"interface_name,omitempty" yaml:"interface_name,omitempty"`
 	// Keepalive is how often to send keepalive requests (seconds).
-	Keepalive int `json:"keepalive,omitempty" yaml:"keepalive,omitempty"`
+	Keepalive *int `json:"keepalive,omitempty" yaml:"keepalive,omitempty"`
 	// LocalPref is apply a local preference to routes received from this peer.
-	LocalPref int `json:"local_pref,omitempty" yaml:"local_pref,omitempty"`
+	LocalPref *int `json:"local_pref,omitempty" yaml:"local_pref,omitempty"`
 	// Md5AuthKey is use the given key for TCP-MD5 authentication with the peer.
 	Md5AuthKey string `json:"md5_auth_key,omitempty" yaml:"md5_auth_key,omitempty"`
 	// MinTtl is require messages from a peer have a minimum IP time to live field.
-	MinTtl int `json:"min_ttl,omitempty" yaml:"min_ttl,omitempty"`
+	MinTtl *int `json:"min_ttl,omitempty" yaml:"min_ttl,omitempty"`
 	// MultiExitDiscriminator is apply the provided multi-exit discriminator (MED) updates sent to the peer.
-	MultiExitDiscriminator int `json:"multi_exit_discriminator,omitempty" yaml:"multi_exit_discriminator,omitempty"`
+	MultiExitDiscriminator *int `json:"multi_exit_discriminator,omitempty" yaml:"multi_exit_discriminator,omitempty"`
 	// RemoteAsn is require that a peer has a specified ASN.
-	RemoteAsn int `json:"remote_asn,omitempty" yaml:"remote_asn,omitempty"`
+	RemoteAsn *int `json:"remote_asn,omitempty" yaml:"remote_asn,omitempty"`
 	// VlanId is associate a VLAN ID with a peer.
-	VlanId int `json:"vlan_id,omitempty" yaml:"vlan_id,omitempty"`
+	VlanId *int `json:"vlan_id,omitempty" yaml:"vlan_id,omitempty"`
 }
 
 // BgpPeerConfig is the type definition for a BgpPeerConfig.
@@ -733,13 +733,13 @@ type BgpPeerStatus struct {
 	// Addr is iP address of the peer.
 	Addr string `json:"addr,omitempty" yaml:"addr,omitempty"`
 	// LocalAsn is local autonomous system number.
-	LocalAsn int `json:"local_asn,omitempty" yaml:"local_asn,omitempty"`
+	LocalAsn *int `json:"local_asn,omitempty" yaml:"local_asn,omitempty"`
 	// RemoteAsn is remote autonomous system number.
-	RemoteAsn int `json:"remote_asn,omitempty" yaml:"remote_asn,omitempty"`
+	RemoteAsn *int `json:"remote_asn,omitempty" yaml:"remote_asn,omitempty"`
 	// State is state of the peer.
 	State BgpPeerState `json:"state,omitempty" yaml:"state,omitempty"`
 	// StateDurationMillis is time of last state change.
-	StateDurationMillis int `json:"state_duration_millis,omitempty" yaml:"state_duration_millis,omitempty"`
+	StateDurationMillis *int `json:"state_duration_millis,omitempty" yaml:"state_duration_millis,omitempty"`
 	// Switch is switch with the peer session.
 	Switch SwitchLocation `json:"switch,omitempty" yaml:"switch,omitempty"`
 }
@@ -849,7 +849,7 @@ type BinRangeint16Type string
 // - End
 // - Type
 type BinRangeint16RangeTo struct {
-	End  int               `json:"end,omitempty" yaml:"end,omitempty"`
+	End  *int              `json:"end,omitempty" yaml:"end,omitempty"`
 	Type BinRangeint16Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -860,8 +860,8 @@ type BinRangeint16RangeTo struct {
 // - Start
 // - Type
 type BinRangeint16Range struct {
-	End   int               `json:"end,omitempty" yaml:"end,omitempty"`
-	Start int               `json:"start,omitempty" yaml:"start,omitempty"`
+	End   *int              `json:"end,omitempty" yaml:"end,omitempty"`
+	Start *int              `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeint16Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -871,7 +871,7 @@ type BinRangeint16Range struct {
 // - Start
 // - Type
 type BinRangeint16RangeFrom struct {
-	Start int               `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int              `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeint16Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -881,11 +881,11 @@ type BinRangeint16RangeFrom struct {
 // cover `(..end)`, `(start..end)`, and `(start..)` respectively.
 type BinRangeint16 struct {
 	// End is the type definition for a End.
-	End int `json:"end,omitempty" yaml:"end,omitempty"`
+	End *int `json:"end,omitempty" yaml:"end,omitempty"`
 	// Type is the type definition for a Type.
 	Type BinRangeint16Type `json:"type,omitempty" yaml:"type,omitempty"`
 	// Start is the type definition for a Start.
-	Start int `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int `json:"start,omitempty" yaml:"start,omitempty"`
 }
 
 // BinRangeint32Type is the type definition for a BinRangeint32Type.
@@ -897,7 +897,7 @@ type BinRangeint32Type string
 // - End
 // - Type
 type BinRangeint32RangeTo struct {
-	End  int               `json:"end,omitempty" yaml:"end,omitempty"`
+	End  *int              `json:"end,omitempty" yaml:"end,omitempty"`
 	Type BinRangeint32Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -908,8 +908,8 @@ type BinRangeint32RangeTo struct {
 // - Start
 // - Type
 type BinRangeint32Range struct {
-	End   int               `json:"end,omitempty" yaml:"end,omitempty"`
-	Start int               `json:"start,omitempty" yaml:"start,omitempty"`
+	End   *int              `json:"end,omitempty" yaml:"end,omitempty"`
+	Start *int              `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeint32Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -919,7 +919,7 @@ type BinRangeint32Range struct {
 // - Start
 // - Type
 type BinRangeint32RangeFrom struct {
-	Start int               `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int              `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeint32Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -929,11 +929,11 @@ type BinRangeint32RangeFrom struct {
 // cover `(..end)`, `(start..end)`, and `(start..)` respectively.
 type BinRangeint32 struct {
 	// End is the type definition for a End.
-	End int `json:"end,omitempty" yaml:"end,omitempty"`
+	End *int `json:"end,omitempty" yaml:"end,omitempty"`
 	// Type is the type definition for a Type.
 	Type BinRangeint32Type `json:"type,omitempty" yaml:"type,omitempty"`
 	// Start is the type definition for a Start.
-	Start int `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int `json:"start,omitempty" yaml:"start,omitempty"`
 }
 
 // BinRangeint64Type is the type definition for a BinRangeint64Type.
@@ -945,7 +945,7 @@ type BinRangeint64Type string
 // - End
 // - Type
 type BinRangeint64RangeTo struct {
-	End  int               `json:"end,omitempty" yaml:"end,omitempty"`
+	End  *int              `json:"end,omitempty" yaml:"end,omitempty"`
 	Type BinRangeint64Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -956,8 +956,8 @@ type BinRangeint64RangeTo struct {
 // - Start
 // - Type
 type BinRangeint64Range struct {
-	End   int               `json:"end,omitempty" yaml:"end,omitempty"`
-	Start int               `json:"start,omitempty" yaml:"start,omitempty"`
+	End   *int              `json:"end,omitempty" yaml:"end,omitempty"`
+	Start *int              `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeint64Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -967,7 +967,7 @@ type BinRangeint64Range struct {
 // - Start
 // - Type
 type BinRangeint64RangeFrom struct {
-	Start int               `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int              `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeint64Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -977,11 +977,11 @@ type BinRangeint64RangeFrom struct {
 // cover `(..end)`, `(start..end)`, and `(start..)` respectively.
 type BinRangeint64 struct {
 	// End is the type definition for a End.
-	End int `json:"end,omitempty" yaml:"end,omitempty"`
+	End *int `json:"end,omitempty" yaml:"end,omitempty"`
 	// Type is the type definition for a Type.
 	Type BinRangeint64Type `json:"type,omitempty" yaml:"type,omitempty"`
 	// Start is the type definition for a Start.
-	Start int `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int `json:"start,omitempty" yaml:"start,omitempty"`
 }
 
 // BinRangeint8Type is the type definition for a BinRangeint8Type.
@@ -993,7 +993,7 @@ type BinRangeint8Type string
 // - End
 // - Type
 type BinRangeint8RangeTo struct {
-	End  int              `json:"end,omitempty" yaml:"end,omitempty"`
+	End  *int             `json:"end,omitempty" yaml:"end,omitempty"`
 	Type BinRangeint8Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1004,8 +1004,8 @@ type BinRangeint8RangeTo struct {
 // - Start
 // - Type
 type BinRangeint8Range struct {
-	End   int              `json:"end,omitempty" yaml:"end,omitempty"`
-	Start int              `json:"start,omitempty" yaml:"start,omitempty"`
+	End   *int             `json:"end,omitempty" yaml:"end,omitempty"`
+	Start *int             `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeint8Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1015,7 +1015,7 @@ type BinRangeint8Range struct {
 // - Start
 // - Type
 type BinRangeint8RangeFrom struct {
-	Start int              `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int             `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeint8Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1025,11 +1025,11 @@ type BinRangeint8RangeFrom struct {
 // cover `(..end)`, `(start..end)`, and `(start..)` respectively.
 type BinRangeint8 struct {
 	// End is the type definition for a End.
-	End int `json:"end,omitempty" yaml:"end,omitempty"`
+	End *int `json:"end,omitempty" yaml:"end,omitempty"`
 	// Type is the type definition for a Type.
 	Type BinRangeint8Type `json:"type,omitempty" yaml:"type,omitempty"`
 	// Start is the type definition for a Start.
-	Start int `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int `json:"start,omitempty" yaml:"start,omitempty"`
 }
 
 // BinRangeuint16Type is the type definition for a BinRangeuint16Type.
@@ -1041,7 +1041,7 @@ type BinRangeuint16Type string
 // - End
 // - Type
 type BinRangeuint16RangeTo struct {
-	End  int                `json:"end,omitempty" yaml:"end,omitempty"`
+	End  *int               `json:"end,omitempty" yaml:"end,omitempty"`
 	Type BinRangeuint16Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1052,8 +1052,8 @@ type BinRangeuint16RangeTo struct {
 // - Start
 // - Type
 type BinRangeuint16Range struct {
-	End   int                `json:"end,omitempty" yaml:"end,omitempty"`
-	Start int                `json:"start,omitempty" yaml:"start,omitempty"`
+	End   *int               `json:"end,omitempty" yaml:"end,omitempty"`
+	Start *int               `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeuint16Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1063,7 +1063,7 @@ type BinRangeuint16Range struct {
 // - Start
 // - Type
 type BinRangeuint16RangeFrom struct {
-	Start int                `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int               `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeuint16Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1073,11 +1073,11 @@ type BinRangeuint16RangeFrom struct {
 // cover `(..end)`, `(start..end)`, and `(start..)` respectively.
 type BinRangeuint16 struct {
 	// End is the type definition for a End.
-	End int `json:"end,omitempty" yaml:"end,omitempty"`
+	End *int `json:"end,omitempty" yaml:"end,omitempty"`
 	// Type is the type definition for a Type.
 	Type BinRangeuint16Type `json:"type,omitempty" yaml:"type,omitempty"`
 	// Start is the type definition for a Start.
-	Start int `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int `json:"start,omitempty" yaml:"start,omitempty"`
 }
 
 // BinRangeuint32Type is the type definition for a BinRangeuint32Type.
@@ -1089,7 +1089,7 @@ type BinRangeuint32Type string
 // - End
 // - Type
 type BinRangeuint32RangeTo struct {
-	End  int                `json:"end,omitempty" yaml:"end,omitempty"`
+	End  *int               `json:"end,omitempty" yaml:"end,omitempty"`
 	Type BinRangeuint32Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1100,8 +1100,8 @@ type BinRangeuint32RangeTo struct {
 // - Start
 // - Type
 type BinRangeuint32Range struct {
-	End   int                `json:"end,omitempty" yaml:"end,omitempty"`
-	Start int                `json:"start,omitempty" yaml:"start,omitempty"`
+	End   *int               `json:"end,omitempty" yaml:"end,omitempty"`
+	Start *int               `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeuint32Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1111,7 +1111,7 @@ type BinRangeuint32Range struct {
 // - Start
 // - Type
 type BinRangeuint32RangeFrom struct {
-	Start int                `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int               `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeuint32Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1121,11 +1121,11 @@ type BinRangeuint32RangeFrom struct {
 // cover `(..end)`, `(start..end)`, and `(start..)` respectively.
 type BinRangeuint32 struct {
 	// End is the type definition for a End.
-	End int `json:"end,omitempty" yaml:"end,omitempty"`
+	End *int `json:"end,omitempty" yaml:"end,omitempty"`
 	// Type is the type definition for a Type.
 	Type BinRangeuint32Type `json:"type,omitempty" yaml:"type,omitempty"`
 	// Start is the type definition for a Start.
-	Start int `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int `json:"start,omitempty" yaml:"start,omitempty"`
 }
 
 // BinRangeuint64Type is the type definition for a BinRangeuint64Type.
@@ -1137,7 +1137,7 @@ type BinRangeuint64Type string
 // - End
 // - Type
 type BinRangeuint64RangeTo struct {
-	End  int                `json:"end,omitempty" yaml:"end,omitempty"`
+	End  *int               `json:"end,omitempty" yaml:"end,omitempty"`
 	Type BinRangeuint64Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1148,8 +1148,8 @@ type BinRangeuint64RangeTo struct {
 // - Start
 // - Type
 type BinRangeuint64Range struct {
-	End   int                `json:"end,omitempty" yaml:"end,omitempty"`
-	Start int                `json:"start,omitempty" yaml:"start,omitempty"`
+	End   *int               `json:"end,omitempty" yaml:"end,omitempty"`
+	Start *int               `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeuint64Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1159,7 +1159,7 @@ type BinRangeuint64Range struct {
 // - Start
 // - Type
 type BinRangeuint64RangeFrom struct {
-	Start int                `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int               `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeuint64Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1169,11 +1169,11 @@ type BinRangeuint64RangeFrom struct {
 // cover `(..end)`, `(start..end)`, and `(start..)` respectively.
 type BinRangeuint64 struct {
 	// End is the type definition for a End.
-	End int `json:"end,omitempty" yaml:"end,omitempty"`
+	End *int `json:"end,omitempty" yaml:"end,omitempty"`
 	// Type is the type definition for a Type.
 	Type BinRangeuint64Type `json:"type,omitempty" yaml:"type,omitempty"`
 	// Start is the type definition for a Start.
-	Start int `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int `json:"start,omitempty" yaml:"start,omitempty"`
 }
 
 // BinRangeuint8Type is the type definition for a BinRangeuint8Type.
@@ -1185,7 +1185,7 @@ type BinRangeuint8Type string
 // - End
 // - Type
 type BinRangeuint8RangeTo struct {
-	End  int               `json:"end,omitempty" yaml:"end,omitempty"`
+	End  *int              `json:"end,omitempty" yaml:"end,omitempty"`
 	Type BinRangeuint8Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1196,8 +1196,8 @@ type BinRangeuint8RangeTo struct {
 // - Start
 // - Type
 type BinRangeuint8Range struct {
-	End   int               `json:"end,omitempty" yaml:"end,omitempty"`
-	Start int               `json:"start,omitempty" yaml:"start,omitempty"`
+	End   *int              `json:"end,omitempty" yaml:"end,omitempty"`
+	Start *int              `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeuint8Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1207,7 +1207,7 @@ type BinRangeuint8Range struct {
 // - Start
 // - Type
 type BinRangeuint8RangeFrom struct {
-	Start int               `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int              `json:"start,omitempty" yaml:"start,omitempty"`
 	Type  BinRangeuint8Type `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1217,11 +1217,11 @@ type BinRangeuint8RangeFrom struct {
 // cover `(..end)`, `(start..end)`, and `(start..)` respectively.
 type BinRangeuint8 struct {
 	// End is the type definition for a End.
-	End int `json:"end,omitempty" yaml:"end,omitempty"`
+	End *int `json:"end,omitempty" yaml:"end,omitempty"`
 	// Type is the type definition for a Type.
 	Type BinRangeuint8Type `json:"type,omitempty" yaml:"type,omitempty"`
 	// Start is the type definition for a Start.
-	Start int `json:"start,omitempty" yaml:"start,omitempty"`
+	Start *int `json:"start,omitempty" yaml:"start,omitempty"`
 }
 
 // Bindouble is type storing bin edges and a count of samples within it.
@@ -1231,7 +1231,7 @@ type BinRangeuint8 struct {
 // - Range
 type Bindouble struct {
 	// Count is the total count of samples in this bin.
-	Count int `json:"count,omitempty" yaml:"count,omitempty"`
+	Count *int `json:"count,omitempty" yaml:"count,omitempty"`
 	// Range is the range of the support covered by this bin.
 	Range BinRangedouble `json:"range,omitempty" yaml:"range,omitempty"`
 }
@@ -1243,7 +1243,7 @@ type Bindouble struct {
 // - Range
 type Binfloat struct {
 	// Count is the total count of samples in this bin.
-	Count int `json:"count,omitempty" yaml:"count,omitempty"`
+	Count *int `json:"count,omitempty" yaml:"count,omitempty"`
 	// Range is the range of the support covered by this bin.
 	Range BinRangefloat `json:"range,omitempty" yaml:"range,omitempty"`
 }
@@ -1255,7 +1255,7 @@ type Binfloat struct {
 // - Range
 type Binint16 struct {
 	// Count is the total count of samples in this bin.
-	Count int `json:"count,omitempty" yaml:"count,omitempty"`
+	Count *int `json:"count,omitempty" yaml:"count,omitempty"`
 	// Range is the range of the support covered by this bin.
 	Range BinRangeint16 `json:"range,omitempty" yaml:"range,omitempty"`
 }
@@ -1267,7 +1267,7 @@ type Binint16 struct {
 // - Range
 type Binint32 struct {
 	// Count is the total count of samples in this bin.
-	Count int `json:"count,omitempty" yaml:"count,omitempty"`
+	Count *int `json:"count,omitempty" yaml:"count,omitempty"`
 	// Range is the range of the support covered by this bin.
 	Range BinRangeint32 `json:"range,omitempty" yaml:"range,omitempty"`
 }
@@ -1279,7 +1279,7 @@ type Binint32 struct {
 // - Range
 type Binint64 struct {
 	// Count is the total count of samples in this bin.
-	Count int `json:"count,omitempty" yaml:"count,omitempty"`
+	Count *int `json:"count,omitempty" yaml:"count,omitempty"`
 	// Range is the range of the support covered by this bin.
 	Range BinRangeint64 `json:"range,omitempty" yaml:"range,omitempty"`
 }
@@ -1291,7 +1291,7 @@ type Binint64 struct {
 // - Range
 type Binint8 struct {
 	// Count is the total count of samples in this bin.
-	Count int `json:"count,omitempty" yaml:"count,omitempty"`
+	Count *int `json:"count,omitempty" yaml:"count,omitempty"`
 	// Range is the range of the support covered by this bin.
 	Range BinRangeint8 `json:"range,omitempty" yaml:"range,omitempty"`
 }
@@ -1303,7 +1303,7 @@ type Binint8 struct {
 // - Range
 type Binuint16 struct {
 	// Count is the total count of samples in this bin.
-	Count int `json:"count,omitempty" yaml:"count,omitempty"`
+	Count *int `json:"count,omitempty" yaml:"count,omitempty"`
 	// Range is the range of the support covered by this bin.
 	Range BinRangeuint16 `json:"range,omitempty" yaml:"range,omitempty"`
 }
@@ -1315,7 +1315,7 @@ type Binuint16 struct {
 // - Range
 type Binuint32 struct {
 	// Count is the total count of samples in this bin.
-	Count int `json:"count,omitempty" yaml:"count,omitempty"`
+	Count *int `json:"count,omitempty" yaml:"count,omitempty"`
 	// Range is the range of the support covered by this bin.
 	Range BinRangeuint32 `json:"range,omitempty" yaml:"range,omitempty"`
 }
@@ -1327,7 +1327,7 @@ type Binuint32 struct {
 // - Range
 type Binuint64 struct {
 	// Count is the total count of samples in this bin.
-	Count int `json:"count,omitempty" yaml:"count,omitempty"`
+	Count *int `json:"count,omitempty" yaml:"count,omitempty"`
 	// Range is the range of the support covered by this bin.
 	Range BinRangeuint64 `json:"range,omitempty" yaml:"range,omitempty"`
 }
@@ -1339,7 +1339,7 @@ type Binuint64 struct {
 // - Range
 type Binuint8 struct {
 	// Count is the total count of samples in this bin.
-	Count int `json:"count,omitempty" yaml:"count,omitempty"`
+	Count *int `json:"count,omitempty" yaml:"count,omitempty"`
 	// Range is the range of the support covered by this bin.
 	Range BinRangeuint8 `json:"range,omitempty" yaml:"range,omitempty"`
 }
@@ -1437,7 +1437,7 @@ type Cumulativefloat struct {
 // - Value
 type Cumulativeint64 struct {
 	StartTime *time.Time `json:"start_time,omitempty" yaml:"start_time,omitempty"`
-	Value     int        `json:"value,omitempty" yaml:"value,omitempty"`
+	Value     *int       `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // Cumulativeuint64 is a cumulative or counter data type.
@@ -1447,7 +1447,7 @@ type Cumulativeint64 struct {
 // - Value
 type Cumulativeuint64 struct {
 	StartTime *time.Time `json:"start_time,omitempty" yaml:"start_time,omitempty"`
-	Value     int        `json:"value,omitempty" yaml:"value,omitempty"`
+	Value     *int       `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // CurrentUser is info about the current user
@@ -1486,7 +1486,7 @@ type DatumBool struct {
 // - Datum
 // - Type
 type DatumI8 struct {
-	Datum int       `json:"datum,omitempty" yaml:"datum,omitempty"`
+	Datum *int      `json:"datum,omitempty" yaml:"datum,omitempty"`
 	Type  DatumType `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1496,7 +1496,7 @@ type DatumI8 struct {
 // - Datum
 // - Type
 type DatumU8 struct {
-	Datum int       `json:"datum,omitempty" yaml:"datum,omitempty"`
+	Datum *int      `json:"datum,omitempty" yaml:"datum,omitempty"`
 	Type  DatumType `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1506,7 +1506,7 @@ type DatumU8 struct {
 // - Datum
 // - Type
 type DatumI16 struct {
-	Datum int       `json:"datum,omitempty" yaml:"datum,omitempty"`
+	Datum *int      `json:"datum,omitempty" yaml:"datum,omitempty"`
 	Type  DatumType `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1516,7 +1516,7 @@ type DatumI16 struct {
 // - Datum
 // - Type
 type DatumU16 struct {
-	Datum int       `json:"datum,omitempty" yaml:"datum,omitempty"`
+	Datum *int      `json:"datum,omitempty" yaml:"datum,omitempty"`
 	Type  DatumType `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1526,7 +1526,7 @@ type DatumU16 struct {
 // - Datum
 // - Type
 type DatumI32 struct {
-	Datum int       `json:"datum,omitempty" yaml:"datum,omitempty"`
+	Datum *int      `json:"datum,omitempty" yaml:"datum,omitempty"`
 	Type  DatumType `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1536,7 +1536,7 @@ type DatumI32 struct {
 // - Datum
 // - Type
 type DatumU32 struct {
-	Datum int       `json:"datum,omitempty" yaml:"datum,omitempty"`
+	Datum *int      `json:"datum,omitempty" yaml:"datum,omitempty"`
 	Type  DatumType `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1546,7 +1546,7 @@ type DatumU32 struct {
 // - Datum
 // - Type
 type DatumI64 struct {
-	Datum int       `json:"datum,omitempty" yaml:"datum,omitempty"`
+	Datum *int      `json:"datum,omitempty" yaml:"datum,omitempty"`
 	Type  DatumType `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -1556,7 +1556,7 @@ type DatumI64 struct {
 // - Datum
 // - Type
 type DatumU64 struct {
-	Datum int       `json:"datum,omitempty" yaml:"datum,omitempty"`
+	Datum *int      `json:"datum,omitempty" yaml:"datum,omitempty"`
 	Type  DatumType `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
@@ -2180,13 +2180,13 @@ type Distributiondouble struct {
 type Distributionint64 struct {
 	Bins         []string `json:"bins,omitempty" yaml:"bins,omitempty"`
 	Counts       []string `json:"counts,omitempty" yaml:"counts,omitempty"`
-	Max          int      `json:"max,omitempty" yaml:"max,omitempty"`
-	Min          int      `json:"min,omitempty" yaml:"min,omitempty"`
+	Max          *int     `json:"max,omitempty" yaml:"max,omitempty"`
+	Min          *int     `json:"min,omitempty" yaml:"min,omitempty"`
 	P50          Quantile `json:"p50,omitempty" yaml:"p50,omitempty"`
 	P90          Quantile `json:"p90,omitempty" yaml:"p90,omitempty"`
 	P99          Quantile `json:"p99,omitempty" yaml:"p99,omitempty"`
 	SquaredMean  float64  `json:"squared_mean,omitempty" yaml:"squared_mean,omitempty"`
-	SumOfSamples int      `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
+	SumOfSamples *int     `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
 }
 
 // EphemeralIpCreate is parameters for creating an ephemeral IP address for an instance.
@@ -2370,7 +2370,7 @@ type FieldValueString struct {
 // - Value
 type FieldValueI8 struct {
 	Type  FieldValueType `json:"type,omitempty" yaml:"type,omitempty"`
-	Value int            `json:"value,omitempty" yaml:"value,omitempty"`
+	Value *int           `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // FieldValueU8 is the type definition for a FieldValueU8.
@@ -2380,7 +2380,7 @@ type FieldValueI8 struct {
 // - Value
 type FieldValueU8 struct {
 	Type  FieldValueType `json:"type,omitempty" yaml:"type,omitempty"`
-	Value int            `json:"value,omitempty" yaml:"value,omitempty"`
+	Value *int           `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // FieldValueI16 is the type definition for a FieldValueI16.
@@ -2390,7 +2390,7 @@ type FieldValueU8 struct {
 // - Value
 type FieldValueI16 struct {
 	Type  FieldValueType `json:"type,omitempty" yaml:"type,omitempty"`
-	Value int            `json:"value,omitempty" yaml:"value,omitempty"`
+	Value *int           `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // FieldValueU16 is the type definition for a FieldValueU16.
@@ -2400,7 +2400,7 @@ type FieldValueI16 struct {
 // - Value
 type FieldValueU16 struct {
 	Type  FieldValueType `json:"type,omitempty" yaml:"type,omitempty"`
-	Value int            `json:"value,omitempty" yaml:"value,omitempty"`
+	Value *int           `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // FieldValueI32 is the type definition for a FieldValueI32.
@@ -2410,7 +2410,7 @@ type FieldValueU16 struct {
 // - Value
 type FieldValueI32 struct {
 	Type  FieldValueType `json:"type,omitempty" yaml:"type,omitempty"`
-	Value int            `json:"value,omitempty" yaml:"value,omitempty"`
+	Value *int           `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // FieldValueU32 is the type definition for a FieldValueU32.
@@ -2420,7 +2420,7 @@ type FieldValueI32 struct {
 // - Value
 type FieldValueU32 struct {
 	Type  FieldValueType `json:"type,omitempty" yaml:"type,omitempty"`
-	Value int            `json:"value,omitempty" yaml:"value,omitempty"`
+	Value *int           `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // FieldValueI64 is the type definition for a FieldValueI64.
@@ -2430,7 +2430,7 @@ type FieldValueU32 struct {
 // - Value
 type FieldValueI64 struct {
 	Type  FieldValueType `json:"type,omitempty" yaml:"type,omitempty"`
-	Value int            `json:"value,omitempty" yaml:"value,omitempty"`
+	Value *int           `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // FieldValueU64 is the type definition for a FieldValueU64.
@@ -2440,7 +2440,7 @@ type FieldValueI64 struct {
 // - Value
 type FieldValueU64 struct {
 	Type  FieldValueType `json:"type,omitempty" yaml:"type,omitempty"`
-	Value int            `json:"value,omitempty" yaml:"value,omitempty"`
+	Value *int           `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // FieldValueIpAddr is the type definition for a FieldValueIpAddr.
@@ -2655,7 +2655,7 @@ type Histogramdouble struct {
 	// Min is the minimum value of all samples in the histogram.
 	Min float64 `json:"min,omitempty" yaml:"min,omitempty"`
 	// NSamples is the total number of samples in the histogram.
-	NSamples int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
+	NSamples *int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
 	// P50 is p50 Quantile
 	P50 Quantile `json:"p50,omitempty" yaml:"p50,omitempty"`
 	// P90 is p95 Quantile
@@ -2700,7 +2700,7 @@ type Histogramfloat struct {
 	// Min is the minimum value of all samples in the histogram.
 	Min float64 `json:"min,omitempty" yaml:"min,omitempty"`
 	// NSamples is the total number of samples in the histogram.
-	NSamples int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
+	NSamples *int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
 	// P50 is p50 Quantile
 	P50 Quantile `json:"p50,omitempty" yaml:"p50,omitempty"`
 	// P90 is p95 Quantile
@@ -2741,11 +2741,11 @@ type Histogramint16 struct {
 	// Bins is the bins of the histogram.
 	Bins []Binint16 `json:"bins,omitempty" yaml:"bins,omitempty"`
 	// Max is the maximum value of all samples in the histogram.
-	Max int `json:"max,omitempty" yaml:"max,omitempty"`
+	Max *int `json:"max,omitempty" yaml:"max,omitempty"`
 	// Min is the minimum value of all samples in the histogram.
-	Min int `json:"min,omitempty" yaml:"min,omitempty"`
+	Min *int `json:"min,omitempty" yaml:"min,omitempty"`
 	// NSamples is the total number of samples in the histogram.
-	NSamples int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
+	NSamples *int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
 	// P50 is p50 Quantile
 	P50 Quantile `json:"p50,omitempty" yaml:"p50,omitempty"`
 	// P90 is p95 Quantile
@@ -2760,7 +2760,7 @@ type Histogramint16 struct {
 	// StartTime is the start time of the histogram.
 	StartTime *time.Time `json:"start_time,omitempty" yaml:"start_time,omitempty"`
 	// SumOfSamples is the sum of all samples in the histogram.
-	SumOfSamples int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
+	SumOfSamples *int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
 }
 
 // Histogramint32 is histogram metric
@@ -2786,11 +2786,11 @@ type Histogramint32 struct {
 	// Bins is the bins of the histogram.
 	Bins []Binint32 `json:"bins,omitempty" yaml:"bins,omitempty"`
 	// Max is the maximum value of all samples in the histogram.
-	Max int `json:"max,omitempty" yaml:"max,omitempty"`
+	Max *int `json:"max,omitempty" yaml:"max,omitempty"`
 	// Min is the minimum value of all samples in the histogram.
-	Min int `json:"min,omitempty" yaml:"min,omitempty"`
+	Min *int `json:"min,omitempty" yaml:"min,omitempty"`
 	// NSamples is the total number of samples in the histogram.
-	NSamples int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
+	NSamples *int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
 	// P50 is p50 Quantile
 	P50 Quantile `json:"p50,omitempty" yaml:"p50,omitempty"`
 	// P90 is p95 Quantile
@@ -2805,7 +2805,7 @@ type Histogramint32 struct {
 	// StartTime is the start time of the histogram.
 	StartTime *time.Time `json:"start_time,omitempty" yaml:"start_time,omitempty"`
 	// SumOfSamples is the sum of all samples in the histogram.
-	SumOfSamples int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
+	SumOfSamples *int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
 }
 
 // Histogramint64 is histogram metric
@@ -2831,11 +2831,11 @@ type Histogramint64 struct {
 	// Bins is the bins of the histogram.
 	Bins []Binint64 `json:"bins,omitempty" yaml:"bins,omitempty"`
 	// Max is the maximum value of all samples in the histogram.
-	Max int `json:"max,omitempty" yaml:"max,omitempty"`
+	Max *int `json:"max,omitempty" yaml:"max,omitempty"`
 	// Min is the minimum value of all samples in the histogram.
-	Min int `json:"min,omitempty" yaml:"min,omitempty"`
+	Min *int `json:"min,omitempty" yaml:"min,omitempty"`
 	// NSamples is the total number of samples in the histogram.
-	NSamples int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
+	NSamples *int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
 	// P50 is p50 Quantile
 	P50 Quantile `json:"p50,omitempty" yaml:"p50,omitempty"`
 	// P90 is p95 Quantile
@@ -2850,7 +2850,7 @@ type Histogramint64 struct {
 	// StartTime is the start time of the histogram.
 	StartTime *time.Time `json:"start_time,omitempty" yaml:"start_time,omitempty"`
 	// SumOfSamples is the sum of all samples in the histogram.
-	SumOfSamples int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
+	SumOfSamples *int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
 }
 
 // Histogramint8 is histogram metric
@@ -2876,11 +2876,11 @@ type Histogramint8 struct {
 	// Bins is the bins of the histogram.
 	Bins []Binint8 `json:"bins,omitempty" yaml:"bins,omitempty"`
 	// Max is the maximum value of all samples in the histogram.
-	Max int `json:"max,omitempty" yaml:"max,omitempty"`
+	Max *int `json:"max,omitempty" yaml:"max,omitempty"`
 	// Min is the minimum value of all samples in the histogram.
-	Min int `json:"min,omitempty" yaml:"min,omitempty"`
+	Min *int `json:"min,omitempty" yaml:"min,omitempty"`
 	// NSamples is the total number of samples in the histogram.
-	NSamples int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
+	NSamples *int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
 	// P50 is p50 Quantile
 	P50 Quantile `json:"p50,omitempty" yaml:"p50,omitempty"`
 	// P90 is p95 Quantile
@@ -2895,7 +2895,7 @@ type Histogramint8 struct {
 	// StartTime is the start time of the histogram.
 	StartTime *time.Time `json:"start_time,omitempty" yaml:"start_time,omitempty"`
 	// SumOfSamples is the sum of all samples in the histogram.
-	SumOfSamples int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
+	SumOfSamples *int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
 }
 
 // Histogramuint16 is histogram metric
@@ -2921,11 +2921,11 @@ type Histogramuint16 struct {
 	// Bins is the bins of the histogram.
 	Bins []Binuint16 `json:"bins,omitempty" yaml:"bins,omitempty"`
 	// Max is the maximum value of all samples in the histogram.
-	Max int `json:"max,omitempty" yaml:"max,omitempty"`
+	Max *int `json:"max,omitempty" yaml:"max,omitempty"`
 	// Min is the minimum value of all samples in the histogram.
-	Min int `json:"min,omitempty" yaml:"min,omitempty"`
+	Min *int `json:"min,omitempty" yaml:"min,omitempty"`
 	// NSamples is the total number of samples in the histogram.
-	NSamples int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
+	NSamples *int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
 	// P50 is p50 Quantile
 	P50 Quantile `json:"p50,omitempty" yaml:"p50,omitempty"`
 	// P90 is p95 Quantile
@@ -2940,7 +2940,7 @@ type Histogramuint16 struct {
 	// StartTime is the start time of the histogram.
 	StartTime *time.Time `json:"start_time,omitempty" yaml:"start_time,omitempty"`
 	// SumOfSamples is the sum of all samples in the histogram.
-	SumOfSamples int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
+	SumOfSamples *int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
 }
 
 // Histogramuint32 is histogram metric
@@ -2966,11 +2966,11 @@ type Histogramuint32 struct {
 	// Bins is the bins of the histogram.
 	Bins []Binuint32 `json:"bins,omitempty" yaml:"bins,omitempty"`
 	// Max is the maximum value of all samples in the histogram.
-	Max int `json:"max,omitempty" yaml:"max,omitempty"`
+	Max *int `json:"max,omitempty" yaml:"max,omitempty"`
 	// Min is the minimum value of all samples in the histogram.
-	Min int `json:"min,omitempty" yaml:"min,omitempty"`
+	Min *int `json:"min,omitempty" yaml:"min,omitempty"`
 	// NSamples is the total number of samples in the histogram.
-	NSamples int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
+	NSamples *int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
 	// P50 is p50 Quantile
 	P50 Quantile `json:"p50,omitempty" yaml:"p50,omitempty"`
 	// P90 is p95 Quantile
@@ -2985,7 +2985,7 @@ type Histogramuint32 struct {
 	// StartTime is the start time of the histogram.
 	StartTime *time.Time `json:"start_time,omitempty" yaml:"start_time,omitempty"`
 	// SumOfSamples is the sum of all samples in the histogram.
-	SumOfSamples int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
+	SumOfSamples *int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
 }
 
 // Histogramuint64 is histogram metric
@@ -3011,11 +3011,11 @@ type Histogramuint64 struct {
 	// Bins is the bins of the histogram.
 	Bins []Binuint64 `json:"bins,omitempty" yaml:"bins,omitempty"`
 	// Max is the maximum value of all samples in the histogram.
-	Max int `json:"max,omitempty" yaml:"max,omitempty"`
+	Max *int `json:"max,omitempty" yaml:"max,omitempty"`
 	// Min is the minimum value of all samples in the histogram.
-	Min int `json:"min,omitempty" yaml:"min,omitempty"`
+	Min *int `json:"min,omitempty" yaml:"min,omitempty"`
 	// NSamples is the total number of samples in the histogram.
-	NSamples int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
+	NSamples *int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
 	// P50 is p50 Quantile
 	P50 Quantile `json:"p50,omitempty" yaml:"p50,omitempty"`
 	// P90 is p95 Quantile
@@ -3030,7 +3030,7 @@ type Histogramuint64 struct {
 	// StartTime is the start time of the histogram.
 	StartTime *time.Time `json:"start_time,omitempty" yaml:"start_time,omitempty"`
 	// SumOfSamples is the sum of all samples in the histogram.
-	SumOfSamples int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
+	SumOfSamples *int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
 }
 
 // Histogramuint8 is histogram metric
@@ -3056,11 +3056,11 @@ type Histogramuint8 struct {
 	// Bins is the bins of the histogram.
 	Bins []Binuint8 `json:"bins,omitempty" yaml:"bins,omitempty"`
 	// Max is the maximum value of all samples in the histogram.
-	Max int `json:"max,omitempty" yaml:"max,omitempty"`
+	Max *int `json:"max,omitempty" yaml:"max,omitempty"`
 	// Min is the minimum value of all samples in the histogram.
-	Min int `json:"min,omitempty" yaml:"min,omitempty"`
+	Min *int `json:"min,omitempty" yaml:"min,omitempty"`
 	// NSamples is the total number of samples in the histogram.
-	NSamples int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
+	NSamples *int `json:"n_samples,omitempty" yaml:"n_samples,omitempty"`
 	// P50 is p50 Quantile
 	P50 Quantile `json:"p50,omitempty" yaml:"p50,omitempty"`
 	// P90 is p95 Quantile
@@ -3075,7 +3075,7 @@ type Histogramuint8 struct {
 	// StartTime is the start time of the histogram.
 	StartTime *time.Time `json:"start_time,omitempty" yaml:"start_time,omitempty"`
 	// SumOfSamples is the sum of all samples in the histogram.
-	SumOfSamples int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
+	SumOfSamples *int `json:"sum_of_samples,omitempty" yaml:"sum_of_samples,omitempty"`
 }
 
 // Hostname is a hostname identifies a host on a network, and is usually a dot-delimited sequence of labels,
@@ -3269,7 +3269,7 @@ type ImageSource struct {
 // - Offset
 type ImportBlocksBulkWrite struct {
 	Base64EncodedData string `json:"base64_encoded_data,omitempty" yaml:"base64_encoded_data,omitempty"`
-	Offset            int    `json:"offset,omitempty" yaml:"offset,omitempty"`
+	Offset            *int   `json:"offset,omitempty" yaml:"offset,omitempty"`
 }
 
 // ImportExportPolicyType is the type definition for a ImportExportPolicyType.
@@ -3649,7 +3649,7 @@ type InstanceSerialConsoleData struct {
 	Data []string `json:"data,omitempty" yaml:"data,omitempty"`
 	// LastByteOffset is the absolute offset since boot (suitable for use as `byte_offset` in a subsequent request)
 	// of the last byte returned in `data`.
-	LastByteOffset int `json:"last_byte_offset,omitempty" yaml:"last_byte_offset,omitempty"`
+	LastByteOffset *int `json:"last_byte_offset,omitempty" yaml:"last_byte_offset,omitempty"`
 }
 
 // InstanceState is the instance is being created.
@@ -4002,10 +4002,10 @@ type Ipv4Range struct {
 // - Capacity
 type Ipv4Utilization struct {
 	// Allocated is the number of IPv4 addresses allocated from this pool
-	Allocated int `json:"allocated,omitempty" yaml:"allocated,omitempty"`
+	Allocated *int `json:"allocated,omitempty" yaml:"allocated,omitempty"`
 	// Capacity is the total number of IPv4 addresses in the pool, i.e., the sum of the lengths of the IPv4 ranges.
 	// Unlike IPv6 capacity, can be a 32-bit integer because there are only 2^32 IPv4 addresses.
-	Capacity int `json:"capacity,omitempty" yaml:"capacity,omitempty"`
+	Capacity *int `json:"capacity,omitempty" yaml:"capacity,omitempty"`
 }
 
 // Ipv6Net is an IPv6 subnet, including prefix and subnet mask
@@ -4058,7 +4058,7 @@ type LinkConfigCreate struct {
 	// Lldp is the link-layer discovery protocol (LLDP) configuration for the link.
 	Lldp LldpLinkConfigCreate `json:"lldp,omitempty" yaml:"lldp,omitempty"`
 	// Mtu is maximum transmission unit for the link.
-	Mtu int `json:"mtu,omitempty" yaml:"mtu,omitempty"`
+	Mtu *int `json:"mtu,omitempty" yaml:"mtu,omitempty"`
 	// Speed is the speed of the link.
 	Speed LinkSpeed `json:"speed,omitempty" yaml:"speed,omitempty"`
 	// TxEq is optional tx_eq settings
@@ -4199,7 +4199,7 @@ type LoopbackAddressCreate struct {
 	//
 	Anycast *bool `json:"anycast,omitempty" yaml:"anycast,omitempty"`
 	// Mask is the subnet mask to use for the address.
-	Mask int `json:"mask,omitempty" yaml:"mask,omitempty"`
+	Mask *int `json:"mask,omitempty" yaml:"mask,omitempty"`
 	// RackId is the containing the switch this loopback address will be configured on.
 	RackId string `json:"rack_id,omitempty" yaml:"rack_id,omitempty"`
 	// SwitchLocation is the location of the switch within the rack this loopback address will be configured on.
@@ -4294,7 +4294,7 @@ type NetworkInterface struct {
 	// can be at most 63 characters long.
 	Name       Name    `json:"name,omitempty" yaml:"name,omitempty"`
 	Primary    *bool   `json:"primary,omitempty" yaml:"primary,omitempty"`
-	Slot       int     `json:"slot,omitempty" yaml:"slot,omitempty"`
+	Slot       *int    `json:"slot,omitempty" yaml:"slot,omitempty"`
 	Subnet     IpNet   `json:"subnet,omitempty" yaml:"subnet,omitempty"`
 	TransitIps []IpNet `json:"transit_ips,omitempty" yaml:"transit_ips,omitempty"`
 	// Vni is a Geneve Virtual Network Identifier
@@ -4510,10 +4510,10 @@ type ProbeCreate struct {
 // - Kind
 // - LastPort
 type ProbeExternalIp struct {
-	FirstPort int                 `json:"first_port,omitempty" yaml:"first_port,omitempty"`
+	FirstPort *int                `json:"first_port,omitempty" yaml:"first_port,omitempty"`
 	Ip        string              `json:"ip,omitempty" yaml:"ip,omitempty"`
 	Kind      ProbeExternalIpKind `json:"kind,omitempty" yaml:"kind,omitempty"`
-	LastPort  int                 `json:"last_port,omitempty" yaml:"last_port,omitempty"`
+	LastPort  *int                `json:"last_port,omitempty" yaml:"last_port,omitempty"`
 }
 
 // ProbeExternalIpKind is the type definition for a ProbeExternalIpKind.
@@ -4723,9 +4723,9 @@ type Route struct {
 	Gw string `json:"gw,omitempty" yaml:"gw,omitempty"`
 	// RibPriority is local preference for route. Higher preference indictes precedence within and across protocols.
 	//
-	RibPriority int `json:"rib_priority,omitempty" yaml:"rib_priority,omitempty"`
+	RibPriority *int `json:"rib_priority,omitempty" yaml:"rib_priority,omitempty"`
 	// Vid is vLAN id the gateway is reachable over.
-	Vid int `json:"vid,omitempty" yaml:"vid,omitempty"`
+	Vid *int `json:"vid,omitempty" yaml:"vid,omitempty"`
 }
 
 // RouteConfig is route configuration data associated with a switch port configuration.
@@ -5168,7 +5168,7 @@ type SiloIpPoolResultsPage struct {
 // - Storage
 type SiloQuotas struct {
 	// Cpus is number of virtual CPUs
-	Cpus int `json:"cpus,omitempty" yaml:"cpus,omitempty"`
+	Cpus *int `json:"cpus,omitempty" yaml:"cpus,omitempty"`
 	// Memory is amount of memory in bytes
 	Memory ByteCount `json:"memory,omitempty" yaml:"memory,omitempty"`
 	SiloId string    `json:"silo_id,omitempty" yaml:"silo_id,omitempty"`
@@ -5184,7 +5184,7 @@ type SiloQuotas struct {
 // - Storage
 type SiloQuotasCreate struct {
 	// Cpus is the amount of virtual CPUs available for running instances in the Silo
-	Cpus int `json:"cpus,omitempty" yaml:"cpus,omitempty"`
+	Cpus *int `json:"cpus,omitempty" yaml:"cpus,omitempty"`
 	// Memory is the amount of RAM (in bytes) available for running instances in the Silo
 	Memory ByteCount `json:"memory,omitempty" yaml:"memory,omitempty"`
 	// Storage is the amount of storage (in bytes) available for disks or snapshots
@@ -5206,7 +5206,7 @@ type SiloQuotasResultsPage struct {
 // be updated.
 type SiloQuotasUpdate struct {
 	// Cpus is the amount of virtual CPUs available for running instances in the Silo
-	Cpus int `json:"cpus,omitempty" yaml:"cpus,omitempty"`
+	Cpus *int `json:"cpus,omitempty" yaml:"cpus,omitempty"`
 	// Memory is the amount of RAM (in bytes) available for running instances in the Silo
 	Memory ByteCount `json:"memory,omitempty" yaml:"memory,omitempty"`
 	// Storage is the amount of storage (in bytes) available for disks or snapshots
@@ -5316,7 +5316,7 @@ type Sled struct {
 	// TimeModified is timestamp when this resource was last modified
 	TimeModified *time.Time `json:"time_modified,omitempty" yaml:"time_modified,omitempty"`
 	// UsableHardwareThreads is the number of hardware threads which can execute on this sled
-	UsableHardwareThreads int `json:"usable_hardware_threads,omitempty" yaml:"usable_hardware_threads,omitempty"`
+	UsableHardwareThreads *int `json:"usable_hardware_threads,omitempty" yaml:"usable_hardware_threads,omitempty"`
 	// UsablePhysicalRam is amount of RAM which may be used by the Sled's OS
 	UsablePhysicalRam ByteCount `json:"usable_physical_ram,omitempty" yaml:"usable_physical_ram,omitempty"`
 }
@@ -5346,13 +5346,13 @@ type SledInstance struct {
 	ActiveSledId string `json:"active_sled_id,omitempty" yaml:"active_sled_id,omitempty"`
 	// Id is unique, immutable, system-controlled identifier for each resource
 	Id          string `json:"id,omitempty" yaml:"id,omitempty"`
-	Memory      int    `json:"memory,omitempty" yaml:"memory,omitempty"`
+	Memory      *int   `json:"memory,omitempty" yaml:"memory,omitempty"`
 	MigrationId string `json:"migration_id,omitempty" yaml:"migration_id,omitempty"`
 	// Name is names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase
 	// ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID, but they may contain a UUID. They
 	// can be at most 63 characters long.
 	Name  Name `json:"name,omitempty" yaml:"name,omitempty"`
-	Ncpus int  `json:"ncpus,omitempty" yaml:"ncpus,omitempty"`
+	Ncpus *int `json:"ncpus,omitempty" yaml:"ncpus,omitempty"`
 	// ProjectName is names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII,
 	// uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID, but they may contain a
 	// UUID. They can be at most 63 characters long.
@@ -5694,7 +5694,7 @@ type SwitchInterfaceKindVlan struct {
 	Type SwitchInterfaceKindType `json:"type,omitempty" yaml:"type,omitempty"`
 	// Vid is the virtual network id (VID) that distinguishes this interface and is used for producing and consuming
 	// 802.1Q Ethernet tags. This field has a maximum value of 4095 as 802.1Q tags are twelve bits.
-	Vid int `json:"vid,omitempty" yaml:"vid,omitempty"`
+	Vid *int `json:"vid,omitempty" yaml:"vid,omitempty"`
 }
 
 // SwitchInterfaceKindLoopback is loopback interfaces are anchors for IP addresses that are not specific to
@@ -5712,7 +5712,7 @@ type SwitchInterfaceKind struct {
 	Type SwitchInterfaceKindType `json:"type,omitempty" yaml:"type,omitempty"`
 	// Vid is the virtual network id (VID) that distinguishes this interface and is used for producing and consuming
 	// 802.1Q Ethernet tags. This field has a maximum value of 4095 as 802.1Q tags are twelve bits.
-	Vid int `json:"vid,omitempty" yaml:"vid,omitempty"`
+	Vid *int `json:"vid,omitempty" yaml:"vid,omitempty"`
 }
 
 // SwitchInterfaceKind2 is primary interfaces are associated with physical links. There is exactly one primary
@@ -5763,7 +5763,7 @@ type SwitchPortAddressConfig struct {
 	// PortSettingsId is the port settings object this address configuration belongs to.
 	PortSettingsId string `json:"port_settings_id,omitempty" yaml:"port_settings_id,omitempty"`
 	// VlanId is an optional VLAN ID
-	VlanId int `json:"vlan_id,omitempty" yaml:"vlan_id,omitempty"`
+	VlanId *int `json:"vlan_id,omitempty" yaml:"vlan_id,omitempty"`
 }
 
 // SwitchPortApplySettings is parameters for applying settings to switch ports.
@@ -5821,7 +5821,7 @@ type SwitchPortLinkConfig struct {
 	// LldpLinkConfigId is the link-layer discovery protocol service configuration id for this link.
 	LldpLinkConfigId string `json:"lldp_link_config_id,omitempty" yaml:"lldp_link_config_id,omitempty"`
 	// Mtu is the maximum transmission unit for this link.
-	Mtu int `json:"mtu,omitempty" yaml:"mtu,omitempty"`
+	Mtu *int `json:"mtu,omitempty" yaml:"mtu,omitempty"`
 	// PortSettingsId is the port settings this link configuration belongs to.
 	PortSettingsId string `json:"port_settings_id,omitempty" yaml:"port_settings_id,omitempty"`
 	// Speed is the configured speed of the link.
@@ -5858,10 +5858,10 @@ type SwitchPortRouteConfig struct {
 	// PortSettingsId is the port settings object this route configuration belongs to.
 	PortSettingsId string `json:"port_settings_id,omitempty" yaml:"port_settings_id,omitempty"`
 	// RibPriority is rIB Priority indicating priority within and across protocols.
-	RibPriority int `json:"rib_priority,omitempty" yaml:"rib_priority,omitempty"`
+	RibPriority *int `json:"rib_priority,omitempty" yaml:"rib_priority,omitempty"`
 	// VlanId is the VLAN identifier for the route. Use this if the gateway is reachable over an 802.1Q tagged L2
 	// segment.
-	VlanId int `json:"vlan_id,omitempty" yaml:"vlan_id,omitempty"`
+	VlanId *int `json:"vlan_id,omitempty" yaml:"vlan_id,omitempty"`
 }
 
 // SwitchPortSettings is a switch port settings identity whose id may be used to view additional details.
@@ -6008,7 +6008,7 @@ type SwitchVlanInterfaceConfig struct {
 	InterfaceConfigId string `json:"interface_config_id,omitempty" yaml:"interface_config_id,omitempty"`
 	// VlanId is the virtual network id for this interface that is used for producing and consuming 802.1Q Ethernet
 	// tags. This field has a maximum value of 4095 as 802.1Q tags are twelve bits.
-	VlanId int `json:"vlan_id,omitempty" yaml:"vlan_id,omitempty"`
+	VlanId *int `json:"vlan_id,omitempty" yaml:"vlan_id,omitempty"`
 }
 
 // SystemMetricName is the type definition for a SystemMetricName.
@@ -6096,7 +6096,7 @@ type TimeseriesSchema struct {
 	TimeseriesName TimeseriesName `json:"timeseries_name,omitempty" yaml:"timeseries_name,omitempty"`
 	// Units is measurement units for timeseries samples.
 	Units   Units `json:"units,omitempty" yaml:"units,omitempty"`
-	Version int   `json:"version,omitempty" yaml:"version,omitempty"`
+	Version *int  `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
 // TimeseriesSchemaResultsPage is a single page of results
@@ -6114,15 +6114,15 @@ type TimeseriesSchemaResultsPage struct {
 // to improve signal integrity.
 type TxEqConfig struct {
 	// Main is main tap
-	Main int `json:"main,omitempty" yaml:"main,omitempty"`
+	Main *int `json:"main,omitempty" yaml:"main,omitempty"`
 	// Post1 is post-cursor tap1
-	Post1 int `json:"post1,omitempty" yaml:"post1,omitempty"`
+	Post1 *int `json:"post1,omitempty" yaml:"post1,omitempty"`
 	// Post2 is post-cursor tap2
-	Post2 int `json:"post2,omitempty" yaml:"post2,omitempty"`
+	Post2 *int `json:"post2,omitempty" yaml:"post2,omitempty"`
 	// Pre1 is pre-cursor tap1
-	Pre1 int `json:"pre1,omitempty" yaml:"pre1,omitempty"`
+	Pre1 *int `json:"pre1,omitempty" yaml:"pre1,omitempty"`
 	// Pre2 is pre-cursor tap2
-	Pre2 int `json:"pre2,omitempty" yaml:"pre2,omitempty"`
+	Pre2 *int `json:"pre2,omitempty" yaml:"pre2,omitempty"`
 }
 
 // TypedUuidForInstanceKind is the type definition for a TypedUuidForInstanceKind.
@@ -6140,7 +6140,7 @@ type TypedUuidForSupportBundleKind string
 type UninitializedSled struct {
 	// Baseboard is properties that uniquely identify an Oxide hardware component
 	Baseboard Baseboard `json:"baseboard,omitempty" yaml:"baseboard,omitempty"`
-	Cubby     int       `json:"cubby,omitempty" yaml:"cubby,omitempty"`
+	Cubby     *int      `json:"cubby,omitempty" yaml:"cubby,omitempty"`
 	RackId    string    `json:"rack_id,omitempty" yaml:"rack_id,omitempty"`
 }
 
@@ -6396,7 +6396,7 @@ type Values struct {
 // - Storage
 type VirtualResourceCounts struct {
 	// Cpus is number of virtual CPUs
-	Cpus int `json:"cpus,omitempty" yaml:"cpus,omitempty"`
+	Cpus *int `json:"cpus,omitempty" yaml:"cpus,omitempty"`
 	// Memory is amount of memory in bytes
 	Memory ByteCount `json:"memory,omitempty" yaml:"memory,omitempty"`
 	// Storage is amount of disk storage in bytes
@@ -6491,7 +6491,7 @@ type VpcFirewallRule struct {
 	// Name is unique, mutable, user-controlled identifier for each resource
 	Name Name `json:"name,omitempty" yaml:"name,omitempty"`
 	// Priority is the relative priority of this rule
-	Priority int `json:"priority,omitempty" yaml:"priority,omitempty"`
+	Priority *int `json:"priority,omitempty" yaml:"priority,omitempty"`
 	// Status is whether this rule is in effect
 	Status VpcFirewallRuleStatus `json:"status,omitempty" yaml:"status,omitempty"`
 	// Targets is determine the set of instances that the rule applies to
@@ -6700,7 +6700,7 @@ type VpcFirewallRuleUpdate struct {
 	// Name is name of the rule, unique to this VPC
 	Name Name `json:"name,omitempty" yaml:"name,omitempty"`
 	// Priority is the relative priority of this rule
-	Priority int `json:"priority,omitempty" yaml:"priority,omitempty"`
+	Priority *int `json:"priority,omitempty" yaml:"priority,omitempty"`
 	// Status is whether this rule is in effect
 	Status VpcFirewallRuleStatus `json:"status,omitempty" yaml:"status,omitempty"`
 	// Targets is determine the set of instances that the rule applies to
@@ -6914,7 +6914,7 @@ type DeviceAccessTokenParams struct {
 // Required fields:
 // - Project
 type ProbeListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -6952,7 +6952,7 @@ type ProbeViewParams struct {
 
 // SupportBundleListParams is the request parameters for SupportBundleList
 type SupportBundleListParams struct {
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -7034,7 +7034,7 @@ type LoginSamlParams struct {
 // Required fields:
 // - Project
 type AffinityGroupListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7084,7 +7084,7 @@ type AffinityGroupUpdateParams struct {
 // Required fields:
 // - AffinityGroup
 type AffinityGroupMemberListParams struct {
-	Limit         int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit         *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken     string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project       NameOrId   `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy        IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7129,7 +7129,7 @@ type AffinityGroupMemberInstanceAddParams struct {
 // Required fields:
 // - Project
 type AntiAffinityGroupListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7179,7 +7179,7 @@ type AntiAffinityGroupUpdateParams struct {
 // Required fields:
 // - AntiAffinityGroup
 type AntiAffinityGroupMemberListParams struct {
-	Limit             int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit             *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken         string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project           NameOrId   `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy            IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7221,7 +7221,7 @@ type AntiAffinityGroupMemberInstanceAddParams struct {
 
 // CertificateListParams is the request parameters for CertificateList
 type CertificateListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -7255,7 +7255,7 @@ type CertificateViewParams struct {
 // Required fields:
 // - Project
 type DiskListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7340,7 +7340,7 @@ type DiskMetricsListParams struct {
 	Disk      NameOrId        `json:"disk,omitempty" yaml:"disk,omitempty"`
 	Metric    DiskMetricName  `json:"metric,omitempty" yaml:"metric,omitempty"`
 	EndTime   *time.Time      `json:"end_time,omitempty" yaml:"end_time,omitempty"`
-	Limit     int             `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int            `json:"limit,omitempty" yaml:"limit,omitempty"`
 	Order     PaginationOrder `json:"order,omitempty" yaml:"order,omitempty"`
 	PageToken string          `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	StartTime *time.Time      `json:"start_time,omitempty" yaml:"start_time,omitempty"`
@@ -7352,7 +7352,7 @@ type DiskMetricsListParams struct {
 // Required fields:
 // - Project
 type FloatingIpListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7419,7 +7419,7 @@ type FloatingIpDetachParams struct {
 
 // GroupListParams is the request parameters for GroupList
 type GroupListParams struct {
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -7434,7 +7434,7 @@ type GroupViewParams struct {
 
 // ImageListParams is the request parameters for ImageList
 type ImageListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7491,7 +7491,7 @@ type ImagePromoteParams struct {
 // Required fields:
 // - Project
 type InstanceListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7541,7 +7541,7 @@ type InstanceUpdateParams struct {
 // Required fields:
 // - Instance
 type InstanceDiskListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7614,9 +7614,9 @@ type InstanceRebootParams struct {
 // - Instance
 type InstanceSerialConsoleParams struct {
 	Instance   NameOrId `json:"instance,omitempty" yaml:"instance,omitempty"`
-	FromStart  int      `json:"from_start,omitempty" yaml:"from_start,omitempty"`
-	MaxBytes   int      `json:"max_bytes,omitempty" yaml:"max_bytes,omitempty"`
-	MostRecent int      `json:"most_recent,omitempty" yaml:"most_recent,omitempty"`
+	FromStart  *int     `json:"from_start,omitempty" yaml:"from_start,omitempty"`
+	MaxBytes   *int     `json:"max_bytes,omitempty" yaml:"max_bytes,omitempty"`
+	MostRecent *int     `json:"most_recent,omitempty" yaml:"most_recent,omitempty"`
 	Project    NameOrId `json:"project,omitempty" yaml:"project,omitempty"`
 }
 
@@ -7626,7 +7626,7 @@ type InstanceSerialConsoleParams struct {
 // - Instance
 type InstanceSerialConsoleStreamParams struct {
 	Instance   NameOrId `json:"instance,omitempty" yaml:"instance,omitempty"`
-	MostRecent int      `json:"most_recent,omitempty" yaml:"most_recent,omitempty"`
+	MostRecent *int     `json:"most_recent,omitempty" yaml:"most_recent,omitempty"`
 	Project    NameOrId `json:"project,omitempty" yaml:"project,omitempty"`
 }
 
@@ -7636,7 +7636,7 @@ type InstanceSerialConsoleStreamParams struct {
 // - Instance
 type InstanceSshPublicKeyListParams struct {
 	Instance  NameOrId         `json:"instance,omitempty" yaml:"instance,omitempty"`
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7666,7 +7666,7 @@ type InstanceStopParams struct {
 // - Gateway
 type InternetGatewayIpAddressListParams struct {
 	Gateway   NameOrId         `json:"gateway,omitempty" yaml:"gateway,omitempty"`
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7703,7 +7703,7 @@ type InternetGatewayIpAddressDeleteParams struct {
 // - Gateway
 type InternetGatewayIpPoolListParams struct {
 	Gateway   NameOrId         `json:"gateway,omitempty" yaml:"gateway,omitempty"`
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7739,7 +7739,7 @@ type InternetGatewayIpPoolDeleteParams struct {
 // Required fields:
 // - Vpc
 type InternetGatewayListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7780,7 +7780,7 @@ type InternetGatewayViewParams struct {
 
 // ProjectIpPoolListParams is the request parameters for ProjectIpPoolList
 type ProjectIpPoolListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -7805,14 +7805,14 @@ type LoginLocalParams struct {
 
 // CurrentUserGroupsParams is the request parameters for CurrentUserGroups
 type CurrentUserGroupsParams struct {
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
 
 // CurrentUserSshKeyListParams is the request parameters for CurrentUserSshKeyList
 type CurrentUserSshKeyListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -7850,7 +7850,7 @@ type CurrentUserSshKeyViewParams struct {
 type SiloMetricParams struct {
 	MetricName SystemMetricName `json:"metric_name,omitempty" yaml:"metric_name,omitempty"`
 	EndTime    *time.Time       `json:"end_time,omitempty" yaml:"end_time,omitempty"`
-	Limit      int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit      *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	Order      PaginationOrder  `json:"order,omitempty" yaml:"order,omitempty"`
 	PageToken  string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	StartTime  *time.Time       `json:"start_time,omitempty" yaml:"start_time,omitempty"`
@@ -7863,7 +7863,7 @@ type SiloMetricParams struct {
 // - Instance
 type InstanceNetworkInterfaceListParams struct {
 	Instance  NameOrId         `json:"instance,omitempty" yaml:"instance,omitempty"`
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -7922,7 +7922,7 @@ type PolicyUpdateParams struct {
 
 // ProjectListParams is the request parameters for ProjectList
 type ProjectListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -7984,7 +7984,7 @@ type ProjectPolicyUpdateParams struct {
 // Required fields:
 // - Project
 type SnapshotListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -8020,7 +8020,7 @@ type SnapshotViewParams struct {
 
 // PhysicalDiskListParams is the request parameters for PhysicalDiskList
 type PhysicalDiskListParams struct {
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8043,14 +8043,14 @@ type NetworkingSwitchPortLldpNeighborsParams struct {
 	Port           Name       `json:"port,omitempty" yaml:"port,omitempty"`
 	RackId         string     `json:"rack_id,omitempty" yaml:"rack_id,omitempty"`
 	SwitchLocation Name       `json:"switch_location,omitempty" yaml:"switch_location,omitempty"`
-	Limit          int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit          *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken      string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy         IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
 
 // RackListParams is the request parameters for RackList
 type RackListParams struct {
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8065,7 +8065,7 @@ type RackViewParams struct {
 
 // SledListParams is the request parameters for SledList
 type SledListParams struct {
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8080,7 +8080,7 @@ type SledAddParams struct {
 
 // SledListUninitializedParams is the request parameters for SledListUninitialized
 type SledListUninitializedParams struct {
-	Limit     int    `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int   `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 }
 
@@ -8098,7 +8098,7 @@ type SledViewParams struct {
 // - SledId
 type SledPhysicalDiskListParams struct {
 	SledId    string     `json:"sled_id,omitempty" yaml:"sled_id,omitempty"`
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8109,7 +8109,7 @@ type SledPhysicalDiskListParams struct {
 // - SledId
 type SledInstanceListParams struct {
 	SledId    string     `json:"sled_id,omitempty" yaml:"sled_id,omitempty"`
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8126,7 +8126,7 @@ type SledSetProvisionPolicyParams struct {
 
 // NetworkingSwitchPortListParams is the request parameters for NetworkingSwitchPortList
 type NetworkingSwitchPortListParams struct {
-	Limit        int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit        *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken    string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy       IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 	SwitchPortId string     `json:"switch_port_id,omitempty" yaml:"switch_port_id,omitempty"`
@@ -8198,7 +8198,7 @@ type NetworkingSwitchPortStatusParams struct {
 
 // SwitchListParams is the request parameters for SwitchList
 type SwitchListParams struct {
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8216,7 +8216,7 @@ type SwitchViewParams struct {
 // Required fields:
 // - Silo
 type SiloIdentityProviderListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Silo      NameOrId         `json:"silo,omitempty" yaml:"silo,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -8276,7 +8276,7 @@ type SamlIdentityProviderViewParams struct {
 
 // IpPoolListParams is the request parameters for IpPoolList
 type IpPoolListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8291,7 +8291,7 @@ type IpPoolCreateParams struct {
 
 // IpPoolServiceRangeListParams is the request parameters for IpPoolServiceRangeList
 type IpPoolServiceRangeListParams struct {
-	Limit     int    `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int   `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 }
 
@@ -8343,7 +8343,7 @@ type IpPoolUpdateParams struct {
 // - Pool
 type IpPoolRangeListParams struct {
 	Pool      NameOrId `json:"pool,omitempty" yaml:"pool,omitempty"`
-	Limit     int      `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int     `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string   `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 }
 
@@ -8373,7 +8373,7 @@ type IpPoolRangeRemoveParams struct {
 // - Pool
 type IpPoolSiloListParams struct {
 	Pool      NameOrId   `json:"pool,omitempty" yaml:"pool,omitempty"`
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8427,7 +8427,7 @@ type IpPoolUtilizationViewParams struct {
 type SystemMetricParams struct {
 	MetricName SystemMetricName `json:"metric_name,omitempty" yaml:"metric_name,omitempty"`
 	EndTime    *time.Time       `json:"end_time,omitempty" yaml:"end_time,omitempty"`
-	Limit      int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit      *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	Order      PaginationOrder  `json:"order,omitempty" yaml:"order,omitempty"`
 	PageToken  string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	StartTime  *time.Time       `json:"start_time,omitempty" yaml:"start_time,omitempty"`
@@ -8436,7 +8436,7 @@ type SystemMetricParams struct {
 
 // NetworkingAddressLotListParams is the request parameters for NetworkingAddressLotList
 type NetworkingAddressLotListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8463,7 +8463,7 @@ type NetworkingAddressLotDeleteParams struct {
 // - AddressLot
 type NetworkingAddressLotBlockListParams struct {
 	AddressLot NameOrId   `json:"address_lot,omitempty" yaml:"address_lot,omitempty"`
-	Limit      int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit      *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken  string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy     IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8502,7 +8502,7 @@ type NetworkingBgpConfigDeleteParams struct {
 
 // NetworkingBgpConfigListParams is the request parameters for NetworkingBgpConfigList
 type NetworkingBgpConfigListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8517,7 +8517,7 @@ type NetworkingBgpConfigCreateParams struct {
 
 // NetworkingBgpAnnounceSetListParams is the request parameters for NetworkingBgpAnnounceSetList
 type NetworkingBgpAnnounceSetListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8551,7 +8551,7 @@ type NetworkingBgpAnnouncementListParams struct {
 // Required fields:
 // - Asn
 type NetworkingBgpMessageHistoryParams struct {
-	Asn int `json:"asn,omitempty" yaml:"asn,omitempty"`
+	Asn *int `json:"asn,omitempty" yaml:"asn,omitempty"`
 }
 
 // NetworkingBgpImportedRoutesIpv4Params is the request parameters for NetworkingBgpImportedRoutesIpv4
@@ -8559,12 +8559,12 @@ type NetworkingBgpMessageHistoryParams struct {
 // Required fields:
 // - Asn
 type NetworkingBgpImportedRoutesIpv4Params struct {
-	Asn int `json:"asn,omitempty" yaml:"asn,omitempty"`
+	Asn *int `json:"asn,omitempty" yaml:"asn,omitempty"`
 }
 
 // NetworkingLoopbackAddressListParams is the request parameters for NetworkingLoopbackAddressList
 type NetworkingLoopbackAddressListParams struct {
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8587,7 +8587,7 @@ type NetworkingLoopbackAddressCreateParams struct {
 type NetworkingLoopbackAddressDeleteParams struct {
 	Address        string `json:"address,omitempty" yaml:"address,omitempty"`
 	RackId         string `json:"rack_id,omitempty" yaml:"rack_id,omitempty"`
-	SubnetMask     int    `json:"subnet_mask,omitempty" yaml:"subnet_mask,omitempty"`
+	SubnetMask     *int   `json:"subnet_mask,omitempty" yaml:"subnet_mask,omitempty"`
 	SwitchLocation Name   `json:"switch_location,omitempty" yaml:"switch_location,omitempty"`
 }
 
@@ -8598,7 +8598,7 @@ type NetworkingSwitchPortSettingsDeleteParams struct {
 
 // NetworkingSwitchPortSettingsListParams is the request parameters for NetworkingSwitchPortSettingsList
 type NetworkingSwitchPortSettingsListParams struct {
-	Limit        int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit        *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken    string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	PortSettings NameOrId         `json:"port_settings,omitempty" yaml:"port_settings,omitempty"`
 	SortBy       NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -8630,7 +8630,7 @@ type SystemPolicyUpdateParams struct {
 
 // RoleListParams is the request parameters for RoleList
 type RoleListParams struct {
-	Limit     int    `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int   `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 }
 
@@ -8644,14 +8644,14 @@ type RoleViewParams struct {
 
 // SystemQuotasListParams is the request parameters for SystemQuotasList
 type SystemQuotasListParams struct {
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
 
 // SiloListParams is the request parameters for SiloList
 type SiloListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8686,7 +8686,7 @@ type SiloViewParams struct {
 // - Silo
 type SiloIpPoolListParams struct {
 	Silo      NameOrId         `json:"silo,omitempty" yaml:"silo,omitempty"`
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8737,7 +8737,7 @@ type SystemTimeseriesQueryParams struct {
 
 // SystemTimeseriesSchemaListParams is the request parameters for SystemTimeseriesSchemaList
 type SystemTimeseriesSchemaListParams struct {
-	Limit     int    `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int   `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 }
 
@@ -8746,7 +8746,7 @@ type SystemTimeseriesSchemaListParams struct {
 // Required fields:
 // - Silo
 type SiloUserListParams struct {
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Silo      NameOrId   `json:"silo,omitempty" yaml:"silo,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -8754,7 +8754,7 @@ type SiloUserListParams struct {
 
 // UserBuiltinListParams is the request parameters for UserBuiltinList
 type UserBuiltinListParams struct {
-	Limit     int          `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int         `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string       `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8779,7 +8779,7 @@ type SiloUserViewParams struct {
 
 // SiloUtilizationListParams is the request parameters for SiloUtilizationList
 type SiloUtilizationListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8805,7 +8805,7 @@ type TimeseriesQueryParams struct {
 // UserListParams is the request parameters for UserList
 type UserListParams struct {
 	Group     string     `json:"group,omitempty" yaml:"group,omitempty"`
-	Limit     int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int       `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string     `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	SortBy    IdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
 }
@@ -8835,7 +8835,7 @@ type VpcFirewallRulesUpdateParams struct {
 // Required fields:
 // - Router
 type VpcRouterRouteListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	Router    NameOrId         `json:"router,omitempty" yaml:"router,omitempty"`
@@ -8896,7 +8896,7 @@ type VpcRouterRouteUpdateParams struct {
 // Required fields:
 // - Vpc
 type VpcRouterListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -8951,7 +8951,7 @@ type VpcRouterUpdateParams struct {
 // Required fields:
 // - Vpc
 type VpcSubnetListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -9007,7 +9007,7 @@ type VpcSubnetUpdateParams struct {
 // - Subnet
 type VpcSubnetListNetworkInterfacesParams struct {
 	Subnet    NameOrId         `json:"subnet,omitempty" yaml:"subnet,omitempty"`
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -9019,7 +9019,7 @@ type VpcSubnetListNetworkInterfacesParams struct {
 // Required fields:
 // - Project
 type VpcListParams struct {
-	Limit     int              `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Limit     *int             `json:"limit,omitempty" yaml:"limit,omitempty"`
 	PageToken string           `json:"page_token,omitempty" yaml:"page_token,omitempty"`
 	Project   NameOrId         `json:"project,omitempty" yaml:"project,omitempty"`
 	SortBy    NameOrIdSortMode `json:"sort_by,omitempty" yaml:"sort_by,omitempty"`
@@ -10823,7 +10823,7 @@ func (p *NetworkingBgpAnnouncementListParams) Validate() error {
 // Validate verifies all required fields for NetworkingBgpMessageHistoryParams are set
 func (p *NetworkingBgpMessageHistoryParams) Validate() error {
 	v := new(Validator)
-	v.HasRequiredNum(int(p.Asn), "Asn")
+	v.HasRequiredNum(p.Asn, "Asn")
 	if !v.IsValid() {
 		return fmt.Errorf("validation error:\n%v", v.Error())
 	}
@@ -10833,7 +10833,7 @@ func (p *NetworkingBgpMessageHistoryParams) Validate() error {
 // Validate verifies all required fields for NetworkingBgpImportedRoutesIpv4Params are set
 func (p *NetworkingBgpImportedRoutesIpv4Params) Validate() error {
 	v := new(Validator)
-	v.HasRequiredNum(int(p.Asn), "Asn")
+	v.HasRequiredNum(p.Asn, "Asn")
 	if !v.IsValid() {
 		return fmt.Errorf("validation error:\n%v", v.Error())
 	}
@@ -10865,7 +10865,7 @@ func (p *NetworkingLoopbackAddressDeleteParams) Validate() error {
 	v.HasRequiredStr(string(p.Address), "Address")
 	v.HasRequiredStr(string(p.RackId), "RackId")
 	v.HasRequiredStr(string(p.SwitchLocation), "SwitchLocation")
-	v.HasRequiredNum(int(p.SubnetMask), "SubnetMask")
+	v.HasRequiredNum(p.SubnetMask, "SubnetMask")
 	if !v.IsValid() {
 		return fmt.Errorf("validation error:\n%v", v.Error())
 	}

--- a/oxide/utils.go
+++ b/oxide/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"text/template"
 )
@@ -11,6 +12,14 @@ import (
 // NewPointer returns a pointer to a given value.
 func NewPointer[T any](v T) *T {
 	return &v
+}
+
+func PointerIntToStr(i *int) string {
+	if i == nil {
+		return ""
+	}
+
+	return strconv.Itoa(*i)
 }
 
 // resolveRelative combines a url base with a relative path.

--- a/oxide/validate.go
+++ b/oxide/validate.go
@@ -24,10 +24,10 @@ func (v *Validator) HasRequiredStr(value, name string) bool {
 	return true
 }
 
-// HasRequiredNum checks that a value is not 0
-func (v *Validator) HasRequiredNum(value int, name string) bool {
-	if value == 0 {
-		v.err = errors.Join(v.err, fmt.Errorf("required value for %s is zero", name))
+// HasRequiredNum checks that a value is not nil
+func (v *Validator) HasRequiredNum(value *int, name string) bool {
+	if value == nil {
+		v.err = errors.Join(v.err, fmt.Errorf("required value for %s is nil", name))
 		return false
 	}
 	return true

--- a/oxide/validate_test.go
+++ b/oxide/validate_test.go
@@ -133,6 +133,15 @@ func TestValidator_HasRequiredNum(t *testing.T) {
 			want: true,
 		},
 		{
+			name:   "int is present when 0",
+			fields: fields{},
+			args: args{
+				value: NewPointer(0),
+				name:  "name",
+			},
+			want: true,
+		},
+		{
 			name:   "int is not present",
 			fields: fields{},
 			args: args{

--- a/oxide/validate_test.go
+++ b/oxide/validate_test.go
@@ -113,7 +113,7 @@ func TestValidator_HasRequiredNum(t *testing.T) {
 		err error
 	}
 	type args struct {
-		value int
+		value *int
 		name  string
 	}
 	tests := []struct {
@@ -127,7 +127,7 @@ func TestValidator_HasRequiredNum(t *testing.T) {
 			name:   "int is present",
 			fields: fields{},
 			args: args{
-				value: 1,
+				value: NewPointer(1),
 				name:  "name",
 			},
 			want: true,
@@ -139,7 +139,7 @@ func TestValidator_HasRequiredNum(t *testing.T) {
 				name: "name",
 			},
 			want:    false,
-			wantErr: errors.Join(errors.New("required value for name is zero")),
+			wantErr: errors.Join(errors.New("required value for name is nil")),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
I've additionally manually tested by updating the terraform provider locally and running all acceptance tests and with the following terraform config:

```hcl
terraform {
  required_version = ">= 1.0"

  required_providers {
    oxide = {
      source  = "oxidecomputer/oxide"
      version = "0.8.0-dev"
    }
  }
}

resource "oxide_vpc_firewall_rules" "talos_k8s_nodeports" {
  vpc_id = "8c2757bc-1cea-422c-ba66-e330bfbcaf92"
  rules = [
    {
      name        = "talos-k8s-nodeports"
      description = "Talos Kubernetes node ports."
      action      = "allow"
      direction   = "inbound"
      priority    = 0
      status      = "enabled"
      filters = {
        ports     = ["30000-32767"]
        protocols = ["TCP"]
      },
      targets = [
        {
          type  = "vpc"
          value = "dud"
        }
      ]
    }
  ]
}
```

```console
$ terraform apply
<...>

Terraform used the selected providers to generate the following execution plan. Resource actions
are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # oxide_vpc_firewall_rules.talos_k8s_nodeports will be created
  + resource "oxide_vpc_firewall_rules" "talos_k8s_nodeports" {
      + id     = (known after apply)
      + rules  = [
          + {
              + action        = "allow"
              + description   = "Talos Kubernetes node ports."
              + direction     = "inbound"
              + filters       = {
                  + ports     = [
                      + "30000-32767",
                    ]
                  + protocols = [
                      + "TCP",
                    ]
                }
              + id            = (known after apply)
              + name          = "talos-k8s-nodeports"
              + priority      = 0
              + status        = "enabled"
              + targets       = [
                  + {
                      + type  = "vpc"
                      + value = "dud"
                    },
                ]
              + time_created  = (known after apply)
              + time_modified = (known after apply)
            },
        ]
      + vpc_id = "8c2757bc-1cea-422c-ba66-e330bfbcaf92"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

oxide_vpc_firewall_rules.talos_k8s_nodeports: Creating...
oxide_vpc_firewall_rules.talos_k8s_nodeports: Creation complete after 0s [id=076a749e-7876-45f1-85dc-fd1bf01ea5a8]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Closes: https://github.com/oxidecomputer/oxide.go/issues/273 https://github.com/oxidecomputer/oxide.go/issues/245 https://github.com/oxidecomputer/terraform-provider-oxide/issues/403