### PR TITLE
generate: set omitzero on specific types

### DIFF
--- a/.changelog/v0.5.0.toml
+++ b/.changelog/v0.5.0.toml
@@ -1,6 +1,8 @@
 [[breaking]]
 title = "Update to Go 1.24"
 description = "Updated the SDK's Go version to Go 1.24. Consumers of this SDK will need to update to Go 1.24 as well. [#291](https://github.com/oxidecomputer/oxide.go/pull/291)"
+title = "Set `omitzero` on specific types"
+description = "Set `omitzero` on specific types so that clients can pass an empty slice and have it serialized as `[]`. Requires Go 1.24 or later. [#289](https://github.com/oxidecomputer/oxide.go/pull/289)"
 
 [[features]]
 title = ""

--- a/internal/generate/exceptions.go
+++ b/internal/generate/exceptions.go
@@ -4,6 +4,16 @@
 
 package main
 
+// omitzeroTypes returns a slice of types that should be tagged with omitzero
+// for serialization and deserialization.
+func omitzeroTypes() []string {
+	return []string{
+		"[]VpcFirewallRuleUpdate",
+		"[]NameOrId",
+		"DerEncodedKeyPair",
+	}
+}
+
 func emptyTypes() []string {
 	return []string{
 		"BgpMessageHistory",

--- a/internal/generate/types.go
+++ b/internal/generate/types.go
@@ -542,9 +542,13 @@ func createTypeObject(schema *openapi3.Schema, name, typeName, description strin
 		field.Name = strcase.ToCamel(k)
 		field.Type = typeName
 
+		// TODO: Set omitzero on all types.
+		// https://github.com/oxidecomputer/oxide.go/issues/290
 		serInfo := fmt.Sprintf("`json:\"%s,omitempty\" yaml:\"%s,omitempty\"`", k, k)
 		if isNullableArray(v) {
 			serInfo = fmt.Sprintf("`json:\"%s\" yaml:\"%s\"`", k, k)
+		} else if sliceContains(omitzeroTypes(), typeName) {
+			serInfo = fmt.Sprintf("`json:\"%s,omitzero\" yaml:\"%s,omitzero\"`", k, k)
 		}
 
 		field.SerializationInfo = serInfo

--- a/oxide/types.go
+++ b/oxide/types.go
@@ -3427,7 +3427,7 @@ type InstanceCpuCount uint16
 // - Ncpus
 type InstanceCreate struct {
 	// AntiAffinityGroups is anti-Affinity groups which this instance should be added.
-	AntiAffinityGroups []NameOrId `json:"anti_affinity_groups,omitempty" yaml:"anti_affinity_groups,omitempty"`
+	AntiAffinityGroups []NameOrId `json:"anti_affinity_groups,omitzero" yaml:"anti_affinity_groups,omitzero"`
 	// AutoRestartPolicy is the auto-restart policy for this instance.
 	//
 	// This policy determines whether the instance should be automatically restarted by the control plane on failure.
@@ -5143,7 +5143,7 @@ type SamlIdentityProviderCreate struct {
 	// can be at most 63 characters long.
 	Name Name `json:"name,omitempty" yaml:"name,omitempty"`
 	// SigningKeypair is request signing key pair
-	SigningKeypair DerEncodedKeyPair `json:"signing_keypair,omitempty" yaml:"signing_keypair,omitempty"`
+	SigningKeypair DerEncodedKeyPair `json:"signing_keypair,omitzero" yaml:"signing_keypair,omitzero"`
 	// SloUrl is service provider endpoint where the idp should send log out requests
 	SloUrl string `json:"slo_url,omitempty" yaml:"slo_url,omitempty"`
 	// SpClientId is sp's client id
@@ -6026,7 +6026,7 @@ type SwitchPortSettingsCreate struct {
 	// BgpPeers is bGP peers indexed by interface name.
 	BgpPeers    BgpPeerConfig `json:"bgp_peers,omitempty" yaml:"bgp_peers,omitempty"`
 	Description string        `json:"description,omitempty" yaml:"description,omitempty"`
-	Groups      []NameOrId    `json:"groups,omitempty" yaml:"groups,omitempty"`
+	Groups      []NameOrId    `json:"groups,omitzero" yaml:"groups,omitzero"`
 	// Interfaces is interfaces indexed by link name.
 	Interfaces SwitchInterfaceConfigCreate `json:"interfaces,omitempty" yaml:"interfaces,omitempty"`
 	// Links is links indexed by phy name. On ports that are not broken out, this is always phy0. On a 2x breakout
@@ -6877,7 +6877,7 @@ type VpcFirewallRuleUpdate struct {
 // Required fields:
 // - Rules
 type VpcFirewallRuleUpdateParams struct {
-	Rules []VpcFirewallRuleUpdate `json:"rules,omitempty" yaml:"rules,omitempty"`
+	Rules []VpcFirewallRuleUpdate `json:"rules,omitzero" yaml:"rules,omitzero"`
 }
 
 // VpcFirewallRules is collection of a Vpc's firewall rules


### PR DESCRIPTION
Set `omitzero` on the following types to allow clients to set an empty slice and have it serialized to `[]`, which is required by Oxide APIs to unset a value.

* `[]VpcFirewallRuleUpdate`
* `[]NameOrId`

The previous behavior would omit an empty slice entirely during serialization, causing the Oxide APIs to respond with an error.