### PR TITLE
misc: use github team for codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @karencfv @sudomateo
+* @karencfv @oxidecomputer/solutions-software-engineering


### PR DESCRIPTION
Updated the `CODEOWNERS` file to use a GitHub team instead of individual users.