### PR TITLE
oxide: optionally build from local openapi spec.

### DIFF
--- a/internal/generate/main.go
+++ b/internal/generate/main.go
@@ -24,10 +24,24 @@ func main() {
 }
 
 func generateSDK() error {
-	versionFile := "../VERSION_OMICRON"
-	spec, err := loadAPIFromFile(versionFile)
-	if err != nil {
-		return err
+	// By default, load the Omicron OpenAPI spec from upstream using a version
+	// hash specified in `../VERSION_OMICRON`. For local testing, optionally
+	// specify a path to an OpenAPI spec file in the `OPENAPI_SPEC_PATH`
+	// environment variable, and use its contents instead.
+	var spec *openapi3.T
+	var err error
+	specFileOverride := os.Getenv("OPENAPI_SPEC_PATH")
+	if specFileOverride != "" {
+		spec, err = openapi3.NewLoader().LoadFromFile(specFileOverride)
+		if err != nil {
+			return err
+		}
+	} else {
+		versionFile := "../VERSION_OMICRON"
+		spec, err = loadAPIFromFile(versionFile)
+		if err != nil {
+			return err
+		}
 	}
 
 	typesFile := "../../oxide/types.go"

--- a/oxide/types.go
+++ b/oxide/types.go
@@ -201,9 +201,6 @@ type AffinityGroupCreate struct {
 	Policy AffinityPolicy `json:"policy,omitempty" yaml:"policy,omitempty"`
 }
 
-// AffinityGroupMemberType is the type definition for a AffinityGroupMemberType.
-type AffinityGroupMemberType string
-
 // AffinityGroupMemberValue is the type definition for a AffinityGroupMemberValue.
 //
 // Required fields:
@@ -222,6 +219,9 @@ type AffinityGroupMemberValue struct {
 	// to the Instance's lifecycle
 	RunState InstanceState `json:"run_state,omitempty" yaml:"run_state,omitempty"`
 }
+
+// AffinityGroupMemberType is the type definition for a AffinityGroupMemberType.
+type AffinityGroupMemberType string
 
 // AffinityGroupMemberInstance is an instance belonging to this group
 //
@@ -596,6 +596,9 @@ type AntiAffinityGroupCreate struct {
 	Policy AffinityPolicy `json:"policy,omitempty" yaml:"policy,omitempty"`
 }
 
+// AntiAffinityGroupMemberType is the type definition for a AntiAffinityGroupMemberType.
+type AntiAffinityGroupMemberType string
+
 // AntiAffinityGroupMemberValue is the type definition for a AntiAffinityGroupMemberValue.
 //
 // Required fields:
@@ -614,9 +617,6 @@ type AntiAffinityGroupMemberValue struct {
 	// to the Instance's lifecycle
 	RunState InstanceState `json:"run_state,omitempty" yaml:"run_state,omitempty"`
 }
-
-// AntiAffinityGroupMemberType is the type definition for a AntiAffinityGroupMemberType.
-type AntiAffinityGroupMemberType string
 
 // AntiAffinityGroupMemberInstance is an instance belonging to this group
 //
@@ -6775,7 +6775,7 @@ type UpdatesTrustRoot struct {
 	// Id is the UUID of this trusted root role.
 	Id string `json:"id,omitempty" yaml:"id,omitempty"`
 	// RootRole is the trusted root role itself, a JSON document as described by The Update Framework.
-	RootRole interface{} `json:"root_role,omitempty" yaml:"root_role,omitempty"`
+	RootRole any `json:"root_role,omitempty" yaml:"root_role,omitempty"`
 	// TimeCreated is time the trusted root role was added.
 	TimeCreated *time.Time `json:"time_created,omitempty" yaml:"time_created,omitempty"`
 }
@@ -9715,7 +9715,7 @@ type SystemUpdateTrustRootListParams struct {
 // Required fields:
 // - Body
 type SystemUpdateTrustRootCreateParams struct {
-	Body *interface{} `json:"body,omitempty" yaml:"body,omitempty"`
+	Body *any `json:"body,omitempty" yaml:"body,omitempty"`
 }
 
 // SystemUpdateTrustRootDeleteParams is the request parameters for SystemUpdateTrustRootDelete


### PR DESCRIPTION
For local testing, we may want to generate the sdk from a local spec file, rather than pulling from github. This patch adds an environment variable override to optionally source the spec from a local file instead.