### PR TITLE
ci/cd: trigger on all push events

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,9 +1,6 @@
 name: build & test
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
 jobs:
   build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updated the workflow to trigger on all push events and not pull request events so that push events on branches by the generate workflow will trigger CI/CD and not hang the pull request for review.

Related to https://github.com/oxidecomputer/oxide.go/issues/292.