### PR TITLE
misc: sort type properties before generating.

### DIFF
--- a/internal/generate/paths.go
+++ b/internal/generate/paths.go
@@ -53,12 +53,7 @@ func generatePaths(file string, spec *openapi3.T) error {
 	defer f.Close()
 
 	// Iterate over all the paths in the spec and write the methods.
-	// We want to ensure we keep the order.
-	keys := make([]string, 0)
-	for k := range spec.Paths.Map() {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	keys := sortedKeys(spec.Paths.Map())
 	for _, path := range keys {
 		p := spec.Paths.Map()[path]
 		if p.Ref != "" {

--- a/internal/generate/responses.go
+++ b/internal/generate/responses.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -25,12 +24,7 @@ func generateResponses(file string, spec *openapi3.T) error {
 	enumCollection := make([]EnumTemplate, 0)
 	typeValidationCollection := make([]ValidationTemplate, 0)
 	// Iterate over all the responses in the spec and write the types.
-	// We want to ensure we keep the order so the diffs don't look like shit.
-	keys := make([]string, 0)
-	for k := range spec.Components.Responses {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	keys := sortedKeys(spec.Components.Responses)
 	for _, name := range keys {
 		r := spec.Components.Responses[name]
 		if r.Ref != "" {

--- a/internal/generate/utils.go
+++ b/internal/generate/utils.go
@@ -7,8 +7,11 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -264,4 +267,11 @@ func allItemsAreSame[T comparable](a []T) bool {
 		}
 	}
 	return true
+}
+
+// sortedKeys returns a []string of sorted keys from a map. Used to ensure deterministic ordering of generated code.
+func sortedKeys[T any](m map[string]T) []string {
+	keys := slices.Collect(maps.Keys(m))
+	sort.Strings(keys)
+	return keys
 }


### PR DESCRIPTION
In order to support deterministic generated code, sort the keys in the type properties map before generating.