### PR TITLE
misc: update deprecated actions syntax.

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Check for modified files
         id: git-check
-        run: echo ::set-output name=modified::$(if git diff-index --ignore-submodules --quiet HEAD --; then echo "false"; else echo "true"; fi)
+        run: echo modified=$(if git diff-index --ignore-submodules --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
 
       - name: Commit changes, if any
         if: steps.git-check.outputs.modified == 'true'

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -33,9 +33,9 @@ jobs:
         id: extract_prerelease
         run: |
           if cat VERSION | grep -q "rc"; then
-            echo "##[set-output name=prerelease;]$(echo true)"
+            echo prerelease=true >> $GITHUB_OUTPUT
           else
-            echo "##[set-output name=prerelease;]$(echo false)"
+            echo prerelease=false >> $GITHUB_OUTPUT
           fi
       - name: Create a Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
The `::set-output` syntax in github actions was deprecated in favor of appending to $GITHUB_OUTPUT:
https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/. This patch updates to the current syntax to avoid deprecation warnings.