### PR TITLE
generate: handle map[string]any types correctly.

### DIFF
--- a/internal/generate/utils.go
+++ b/internal/generate/utils.go
@@ -53,14 +53,6 @@ func isLocalObject(v *openapi3.SchemaRef) bool {
 	return v.Ref == "" && v.Value.Type.Is("object") && len(v.Value.Properties) > 0
 }
 
-func isObjectArray(v *openapi3.SchemaRef) bool {
-	if v.Value.AdditionalProperties.Schema != nil {
-		return v.Value.AdditionalProperties.Schema.Value.Type.Is("array")
-	}
-
-	return false
-}
-
 func isNullableArray(v *openapi3.SchemaRef) bool {
 	return v.Value.Type.Is("array") && v.Value.Nullable
 }

--- a/oxide/types.go
+++ b/oxide/types.go
@@ -6248,7 +6248,7 @@ type Switch struct {
 // - Switch
 type SwitchBgpHistory struct {
 	// History is message history indexed by peer address.
-	History BgpMessageHistory `json:"history,omitempty" yaml:"history,omitempty"`
+	History map[string]BgpMessageHistory `json:"history,omitempty" yaml:"history,omitempty"`
 	// Switch is switch this message history is associated with.
 	Switch SwitchLocation `json:"switch,omitempty" yaml:"switch,omitempty"`
 }
@@ -6649,8 +6649,8 @@ type SystemMetricName string
 // - Name
 // - Timeseries
 type Table struct {
-	Name       string     `json:"name,omitempty" yaml:"name,omitempty"`
-	Timeseries Timeseries `json:"timeseries,omitempty" yaml:"timeseries,omitempty"`
+	Name       string                `json:"name,omitempty" yaml:"name,omitempty"`
+	Timeseries map[string]Timeseries `json:"timeseries,omitempty" yaml:"timeseries,omitempty"`
 }
 
 // TargetRelease is view of a system software target release.
@@ -6709,7 +6709,7 @@ type TimeAndIdSortMode string
 // - Fields
 // - Points
 type Timeseries struct {
-	Fields FieldValue `json:"fields,omitempty" yaml:"fields,omitempty"`
+	Fields map[string]FieldValue `json:"fields,omitempty" yaml:"fields,omitempty"`
 	// Points is timepoints and values for one timeseries.
 	Points Points `json:"points,omitempty" yaml:"points,omitempty"`
 }


### PR DESCRIPTION
When an openapi field includes an `additionalProperties` key, it represents a map to the type specified in the schema reference. We already correctly handle the special case of mapping a string to a slice of the referenced type as a `map[string][]type`, but not the case where the nested type isn't a slice. This patch adds logic for the missing `map[string[type` case.