### PR TITLE
Handle nullable array items.

### DIFF
--- a/oxide/types.go
+++ b/oxide/types.go
@@ -7175,8 +7175,8 @@ type ValueArrayString struct {
 // - Type
 // - Values
 type ValueArrayIntegerDistribution struct {
-	Type   ValueArrayType `json:"type" yaml:"type"`
-	Values []any          `json:"values" yaml:"values"`
+	Type   ValueArrayType      `json:"type" yaml:"type"`
+	Values []Distributionint64 `json:"values" yaml:"values"`
 }
 
 // ValueArrayDoubleDistribution is the type definition for a ValueArrayDoubleDistribution.
@@ -7185,8 +7185,8 @@ type ValueArrayIntegerDistribution struct {
 // - Type
 // - Values
 type ValueArrayDoubleDistribution struct {
-	Type   ValueArrayType `json:"type" yaml:"type"`
-	Values []any          `json:"values" yaml:"values"`
+	Type   ValueArrayType       `json:"type" yaml:"type"`
+	Values []Distributiondouble `json:"values" yaml:"values"`
 }
 
 // ValueArray is list of data values for one timeseries.


### PR DESCRIPTION
Openapi represents an array of nullable items using an allOf with exactly one reference entry (items.allOf[0].$ref), rather than the usual items.$ref. We currently treat these types as any, which means users have to cast or marshal and unmarshal data to the correct type. This patch adds a check for this edge case and replaces the any with the appropriate concrete type.

Part of #340.