### PR TITLE
Refactor and test enum type creation

### DIFF
--- a/internal/generate/utils.go
+++ b/internal/generate/utils.go
@@ -76,23 +76,6 @@ func toLowerFirstLetter(str string) string {
 	return ""
 }
 
-func trimStringFromSpace(s string) string {
-	if idx := strings.Index(s, " "); idx != -1 {
-		return s[:idx]
-	}
-	return s
-}
-
-func containsMatchFirstWord(s []string, str string) bool {
-	for _, v := range s {
-		if trimStringFromSpace(v) == trimStringFromSpace(str) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func isPageParam(s string) bool {
 	return s == "nextPage" || s == "pageToken" || s == "limit"
 }
@@ -243,15 +226,6 @@ func isNumericType(str string) bool {
 	numTypes := []string{"int", "int8", "int16", "int32", "int64", "uint", "uint8",
 		"uint16", "uint32", "uint64", "uintptr", "float32", "float64"}
 	return slices.Contains(numTypes, str)
-}
-
-func allItemsAreSame[T comparable](a []T) bool {
-	for _, v := range a {
-		if v != a[0] {
-			return false
-		}
-	}
-	return true
 }
 
 // sortedKeys returns a []string of sorted keys from a map. Used to ensure


### PR DESCRIPTION
In thinking through #342, I noticed that the enum type creation logic in createOneOf is a bit hard to follow, and not tested thoroughly. In advance of changing that behavior, I wanted to clean up the existing logic and add some tests. This should make the code more readable and easier to change in the future.

Relates to #350. 
Relates to SSE-123.