### PR TITLE
feat: refactor client construction to use functional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ import (
 )
 
 func main() {
-	cfg := oxide.Config{
-		Host:  "https://api.oxide.computer",
-		Token: "oxide-abc123",
-	}
-	client, err := oxide.NewClient(&cfg)
+	client, err := oxide.NewClient(
+		oxide.WithHost("https://api.oxide.computer"),
+		oxide.WithToken("oxide-abc123"),
+	)
 	if err != nil {
 		panic(err)
 	}
@@ -62,13 +61,13 @@ func main() {
 
 The client supports several authentication methods.
 
-1. Explicit configuration: Set `Host` and `Token` in the `Config`:
+1. Explicit options: Use `WithHost` and `WithToken`:
 
    ```go
-   cfg := oxide.Config{
-       Host:  "https://api.oxide.computer",
-       Token: "oxide-abc123",
-   }
+   client, err := oxide.NewClient(
+       oxide.WithHost("https://api.oxide.computer"),
+       oxide.WithToken("oxide-abc123"),
+   )
    ```
 
 1. Environment variables: Set `OXIDE_HOST` and `OXIDE_TOKEN`:
@@ -78,24 +77,34 @@ The client supports several authentication methods.
    export OXIDE_TOKEN="oxide-abc123"
    ```
 
-1. Oxide profile: Use a profile from the Oxide config file:
-   - Set `Profile` in the `Config`:
-     ```go
-     cfg := oxide.Config{
-         Profile: "my-profile",
-     }
-     ```
-   - Or set the `OXIDE_PROFILE` environment variable:
-     ```bash
-     export OXIDE_PROFILE="my-profile"
-     ```
+   Then create the client with no options:
 
-1. Default profile: Use the default profile from the Oxide config file:
    ```go
-   cfg := oxide.Config{
-       UseDefaultProfile: true,
-   }
+   client, err := oxide.NewClient()
    ```
 
-When using profiles, the client reads from the Oxide CLI configuration files located at `$HOME/.config/oxide/credentials.toml` (or a custom directory via `Config.ConfigDir`).
-Values defined in `Config` have higher precedence and override environment variables. Configuring both profile and host/token authentication is disallowed and will return an error from oxide.NewClient, as well configuring both a profile and the default profile.
+1. Oxide profile: Use a profile from the Oxide config file:
+
+   ```go
+   client, err := oxide.NewClient(oxide.WithProfile("my-profile"))
+   ```
+
+   Or set the `OXIDE_PROFILE` environment variable:
+
+   ```bash
+   export OXIDE_PROFILE="my-profile"
+   ```
+
+1. Default profile: Use the default profile from the Oxide config file:
+
+   ```go
+   client, err := oxide.NewClient(oxide.WithDefaultProfile())
+   ```
+
+When using profiles, the client reads from the Oxide credentials file
+located at `$HOME/.config/oxide/credentials.toml`, or a custom directory via
+`WithConfigDir`.
+
+Options override environment variables. Configuring both profile and host/token
+options is disallowed and will return an error, as will configuring both
+`WithProfile` and `WithDefaultProfile`.


### PR DESCRIPTION
Update the `NewClient` constructor to use the functional options pattern to provide a cleaner API that allows users to construct a client with just the configuration they need, or a default client using environment variables.

Here's a comparison.

```go
// Configuration from environment variables.

// Before.
c, err := oxide.NewClient(nil)

// After.
c, err := oxide.NewClient()

// Manual configuration.

// Before.
c, err := oxide.NewClient(oxide.Config{
  Host:  "https://api.oxide.computer",
  Token: "oxide-abc123",
})

// After
c, err := oxide.NewClient(
  WithHost("https://api.oxide.computer"),
  WithToken("oxide-abc123"),
)
```

All in all the user experience is similar barring removing the `nil` for a default client and giving us the ability to add functional options without it being a breaking change like it was with the configuration struct (e.g., for users that use a struct literal). More importantly, though, is the functional options approach is more self-documenting than the configuration struct and is idiomatic with LSP clients.

The changes here are like for like with the previous configuration struct with the exception that now an error is returned when a conflicting envrionment variable and option is provided, rather than the previous behavior of the configuration struct overwriting the environment variable.

Amp-Thread: https://ampcode.com/threads/T-019b9634-5180-729c-acb8-c6e683314736