### PR TITLE
Drop flat structs for complex union types.

### DIFF
--- a/internal/generate/exceptions.go
+++ b/internal/generate/exceptions.go
@@ -22,10 +22,7 @@ func emptyTypes() []string {
 }
 
 func nullable() []string {
-	// TODO: This type has a nested required "Type" field, which hinders
-	// the usage of this type. Remove when this is fixed in the upstream API
 	return []string{
-		"InstanceDiskAttachment",
 		"LldpLinkConfig",
 		"TxEqConfig",
 		"TxEqConfig2",

--- a/internal/generate/test_utils/types_output
+++ b/internal/generate/test_utils/types_output
@@ -19,31 +19,109 @@ type DiskIdentifier struct {
 }
 
 
+// diskSourceVariant is implemented by DiskSource variants.
+type diskSourceVariant interface {
+	isDiskSourceVariant()
+}
+
+
 // DiskSourceType is the type definition for a DiskSourceType.
 type DiskSourceType string
 
-// DiskSourceSnapshot is create a disk from a disk snapshot
+// DiskSourceSnapshot is a variant of DiskSource.
 type DiskSourceSnapshot struct {
 	SnapshotId string `json:"snapshot_id,omitempty" yaml:"snapshot_id,omitempty"`
-	Type DiskSourceType `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
+func (DiskSourceSnapshot) isDiskSourceVariant() {}
 
-// DiskSourceImage is create a disk from a project image
+
+// DiskSourceImage is a variant of DiskSource.
 type DiskSourceImage struct {
 	ImageId string `json:"image_id,omitempty" yaml:"image_id,omitempty"`
-	Type DiskSourceType `json:"type,omitempty" yaml:"type,omitempty"`
 }
+
+func (DiskSourceImage) isDiskSourceVariant() {}
 
 
 // DiskSource is the type definition for a DiskSource.
 type DiskSource struct {
-	// SnapshotId is the type definition for a SnapshotId.
-	SnapshotId string `json:"snapshot_id,omitempty" yaml:"snapshot_id,omitempty"`
-	// Type is the type definition for a Type.
-	Type DiskSourceType `json:"type,omitempty" yaml:"type,omitempty"`
-	// ImageId is the type definition for a ImageId.
-	ImageId string `json:"image_id,omitempty" yaml:"image_id,omitempty"`
+	Value diskSourceVariant 
+}
+
+func (v DiskSource) Type() DiskSourceType {
+	switch v.Value.(type) {
+	case DiskSourceSnapshot, *DiskSourceSnapshot:
+		return DiskSourceTypeSnapshot
+	case DiskSourceImage, *DiskSourceImage:
+		return DiskSourceTypeImage
+	default:
+		return ""
+	}
+}
+
+func (v *DiskSource) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+	type discriminator struct {
+		Type string `json:"type"`
+	}
+	var d discriminator
+	if err := json.Unmarshal(data, &d); err != nil {
+		return err
+	}
+
+	var value diskSourceVariant
+	switch d.Type {
+	case "snapshot":
+		value = &DiskSourceSnapshot{}
+	case "image":
+		value = &DiskSourceImage{}
+	default:
+		return fmt.Errorf("unknown variant %q, expected 'snapshot' or 'image'", d.Type)
+	}
+	if err := json.Unmarshal(data, value); err != nil {
+		return err
+	}
+	v.Value = value
+	return nil
+}
+
+func (v DiskSource) MarshalJSON() ([]byte, error) {
+	if v.Value == nil {
+		return []byte("null"), nil
+	}
+	m := make(map[string]any)
+	m["type"] = v.Type()
+	valueBytes, err := json.Marshal(v.Value)
+	if err != nil {
+		return nil, err
+	}
+	var valueMap map[string]any
+	if err := json.Unmarshal(valueBytes, &valueMap); err != nil {
+		return nil, err
+	}
+	for k, val := range valueMap {
+		m[k] = val
+	}
+	return json.Marshal(m)
+}
+
+
+
+// AsSnapshot attempts to convert the DiskSource to a DiskSourceSnapshot.
+// Returns the variant and true if the conversion succeeded, nil and false otherwise.
+func (v DiskSource) AsSnapshot() (*DiskSourceSnapshot, bool) {
+	val, ok := v.Value.(*DiskSourceSnapshot)
+	return val, ok
+}
+
+// AsImage attempts to convert the DiskSource to a DiskSourceImage.
+// Returns the variant and true if the conversion succeeded, nil and false otherwise.
+func (v DiskSource) AsImage() (*DiskSourceImage, bool) {
+	val, ok := v.Value.(*DiskSourceImage)
+	return val, ok
 }
 
 

--- a/internal/generate/test_utils/types_output_expected
+++ b/internal/generate/test_utils/types_output_expected
@@ -19,31 +19,109 @@ type DiskIdentifier struct {
 }
 
 
+// diskSourceVariant is implemented by DiskSource variants.
+type diskSourceVariant interface {
+	isDiskSourceVariant()
+}
+
+
 // DiskSourceType is the type definition for a DiskSourceType.
 type DiskSourceType string
 
-// DiskSourceSnapshot is create a disk from a disk snapshot
+// DiskSourceSnapshot is a variant of DiskSource.
 type DiskSourceSnapshot struct {
 	SnapshotId string `json:"snapshot_id,omitempty" yaml:"snapshot_id,omitempty"`
-	Type DiskSourceType `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
+func (DiskSourceSnapshot) isDiskSourceVariant() {}
 
-// DiskSourceImage is create a disk from a project image
+
+// DiskSourceImage is a variant of DiskSource.
 type DiskSourceImage struct {
 	ImageId string `json:"image_id,omitempty" yaml:"image_id,omitempty"`
-	Type DiskSourceType `json:"type,omitempty" yaml:"type,omitempty"`
 }
+
+func (DiskSourceImage) isDiskSourceVariant() {}
 
 
 // DiskSource is the type definition for a DiskSource.
 type DiskSource struct {
-	// SnapshotId is the type definition for a SnapshotId.
-	SnapshotId string `json:"snapshot_id,omitempty" yaml:"snapshot_id,omitempty"`
-	// Type is the type definition for a Type.
-	Type DiskSourceType `json:"type,omitempty" yaml:"type,omitempty"`
-	// ImageId is the type definition for a ImageId.
-	ImageId string `json:"image_id,omitempty" yaml:"image_id,omitempty"`
+	Value diskSourceVariant 
+}
+
+func (v DiskSource) Type() DiskSourceType {
+	switch v.Value.(type) {
+	case DiskSourceSnapshot, *DiskSourceSnapshot:
+		return DiskSourceTypeSnapshot
+	case DiskSourceImage, *DiskSourceImage:
+		return DiskSourceTypeImage
+	default:
+		return ""
+	}
+}
+
+func (v *DiskSource) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+	type discriminator struct {
+		Type string `json:"type"`
+	}
+	var d discriminator
+	if err := json.Unmarshal(data, &d); err != nil {
+		return err
+	}
+
+	var value diskSourceVariant
+	switch d.Type {
+	case "snapshot":
+		value = &DiskSourceSnapshot{}
+	case "image":
+		value = &DiskSourceImage{}
+	default:
+		return fmt.Errorf("unknown variant %q, expected 'snapshot' or 'image'", d.Type)
+	}
+	if err := json.Unmarshal(data, value); err != nil {
+		return err
+	}
+	v.Value = value
+	return nil
+}
+
+func (v DiskSource) MarshalJSON() ([]byte, error) {
+	if v.Value == nil {
+		return []byte("null"), nil
+	}
+	m := make(map[string]any)
+	m["type"] = v.Type()
+	valueBytes, err := json.Marshal(v.Value)
+	if err != nil {
+		return nil, err
+	}
+	var valueMap map[string]any
+	if err := json.Unmarshal(valueBytes, &valueMap); err != nil {
+		return nil, err
+	}
+	for k, val := range valueMap {
+		m[k] = val
+	}
+	return json.Marshal(m)
+}
+
+
+
+// AsSnapshot attempts to convert the DiskSource to a DiskSourceSnapshot.
+// Returns the variant and true if the conversion succeeded, nil and false otherwise.
+func (v DiskSource) AsSnapshot() (*DiskSourceSnapshot, bool) {
+	val, ok := v.Value.(*DiskSourceSnapshot)
+	return val, ok
+}
+
+// AsImage attempts to convert the DiskSource to a DiskSourceImage.
+// Returns the variant and true if the conversion succeeded, nil and false otherwise.
+func (v DiskSource) AsImage() (*DiskSourceImage, bool) {
+	val, ok := v.Value.(*DiskSourceImage)
+	return val, ok
 }
 
 

--- a/internal/generate/types_test.go
+++ b/internal/generate/types_test.go
@@ -425,42 +425,62 @@ func Test_createOneOf(t *testing.T) {
 			},
 			typeName: "ImageSource",
 			wantTypes: []TypeTemplate{
+				// Interface for variant types
+				{
+					Description:   "// imageSourceVariant is implemented by ImageSource variants.",
+					Name:          "imageSourceVariant",
+					Type:          "interface",
+					VariantMarker: "isImageSourceVariant",
+				},
 				{
 					Description: "// ImageSourceType is the type definition for a ImageSourceType.",
 					Name:        "ImageSourceType",
 					Type:        "string",
 				},
 				{
-					Description: "// ImageSourceUrl is the type definition for a ImageSourceUrl.\n//\n// Required fields:\n// - Type\n// - Url",
+					Description: "// ImageSourceUrl is a variant of ImageSource.",
 					Name:        "ImageSourceUrl",
 					Type:        "struct",
 					Fields: []TypeField{
-						{Name: "Type", Type: "ImageSourceType", MarshalKey: "type", Required: true},
 						{Name: "Url", Type: "string", MarshalKey: "url", Required: true},
 					},
+					VariantMarker: "isImageSourceVariant",
 				},
 				{
-					Description: "// ImageSourceSnapshot is the type definition for a ImageSourceSnapshot.\n//\n// Required fields:\n// - Id\n// - Type",
+					Description: "// ImageSourceSnapshot is a variant of ImageSource.",
 					Name:        "ImageSourceSnapshot",
 					Type:        "struct",
 					Fields: []TypeField{
 						{Name: "Id", Type: "string", MarshalKey: "id", Required: true},
-						{Name: "Type", Type: "ImageSourceType", MarshalKey: "type", Required: true},
 					},
+					VariantMarker: "isImageSourceVariant",
 				},
 				{
 					Description: "// ImageSource is the source of the underlying image.",
 					Name:        "ImageSource",
 					Type:        "struct",
 					Fields: []TypeField{
-						{
-							Name:                "Type",
-							Type:                "ImageSourceType",
-							MarshalKey:          "type",
-							FallbackDescription: true,
+						{Name: "Value", Type: "imageSourceVariant"},
+					},
+					Union: &UnionConfig{
+						UnionType:           UnionTagged,
+						Discriminator:       "type",
+						DiscriminatorMethod: "Type",
+						DiscriminatorType:   "ImageSourceType",
+						ValueFieldName:      "Value",
+						VariantType:         "imageSourceVariant",
+						Variants: []Variant{
+							{
+								DiscriminatorValue: "url",
+								TypeSuffix:         "Url",
+								TypeName:           "ImageSourceUrl",
+							},
+							{
+								DiscriminatorValue: "snapshot",
+								TypeSuffix:         "Snapshot",
+								TypeName:           "ImageSourceSnapshot",
+							},
 						},
-						{Name: "Url", Type: "string", MarshalKey: "url", FallbackDescription: true},
-						{Name: "Id", Type: "string", MarshalKey: "id", FallbackDescription: true},
 					},
 				},
 			},
@@ -562,7 +582,6 @@ func Test_createOneOf(t *testing.T) {
 						Discriminator:       "type",
 						DiscriminatorMethod: "Type",
 						DiscriminatorType:   "IntOrStringType",
-						ValueField:          "value",
 						ValueFieldName:      "Value",
 						VariantType:         "intOrStringVariant",
 						Variants: []Variant{


### PR DESCRIPTION
Earlier, we switched from `any` to interfaces with variant structs to represent tagged unions with a single value field. We left tagged unions with multiple value fields as flat structs at the time. This patch finishes the migration to interfaces for all tagged unions.

Downstream PRs:
* terraform provider: https://github.com/oxidecomputer/terraform-provider-oxide/pull/638
* packer plugin: https://github.com/oxidecomputer/packer-plugin-oxide/pull/61
* otel receiver: https://github.com/oxidecomputer/oxidereceiver/pull/17