### PR TITLE
docs: add v0.8.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.8.0
+# v0.8.0 (2026/Feb/17)
 
 Generated from Oxide API version
 [2026021301.0.0](https://github.com/oxidecomputer/omicron/blob/rel/v18/rc1/openapi/nexus/nexus-2026021301.0.0-6e51ab.json)


### PR DESCRIPTION
While working on https://github.com/oxidecomputer/oxide.go/pull/387, I realized I forgot this step.