### PR TITLE
Handle nil timestamps in query parameters.

### DIFF
--- a/internal/generate/paths.go
+++ b/internal/generate/paths.go
@@ -426,10 +426,7 @@ func buildPathOrQueryParams(
 			case "*int":
 				pathParams = append(pathParams, fmt.Sprintf("%q: PointerIntToStr(%s),", name, n))
 			case "*time.Time":
-				pathParams = append(
-					pathParams,
-					fmt.Sprintf("%q: %s.Format(time.RFC3339),", name, n),
-				)
+				pathParams = append(pathParams, fmt.Sprintf("%q: PointerTimeToStr(%s),", name, n))
 			default:
 				if p.Schema.Value != nil && p.Schema.Value.Type.Is("integer") {
 					pathParams = append(pathParams, fmt.Sprintf("%q: fmt.Sprint(%s),", name, n))

--- a/oxide/paths.go
+++ b/oxide/paths.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"time"
 )
 
 // EXPERIMENTAL: This operation is not yet stable and may change or be removed without notice.
@@ -7024,12 +7023,12 @@ func (c *Client) SiloMetric(
 			"metric_name": string(params.MetricName),
 		},
 		map[string]string{
-			"end_time":   params.EndTime.Format(time.RFC3339),
+			"end_time":   PointerTimeToStr(params.EndTime),
 			"limit":      PointerIntToStr(params.Limit),
 			"order":      string(params.Order),
 			"page_token": params.PageToken,
 			"project":    string(params.Project),
-			"start_time": params.StartTime.Format(time.RFC3339),
+			"start_time": PointerTimeToStr(params.StartTime),
 		},
 	)
 	if err != nil {
@@ -8506,11 +8505,11 @@ func (c *Client) AuditLogList(
 		resolveRelative(c.host, "/v1/system/audit-log"),
 		map[string]string{},
 		map[string]string{
-			"end_time":   params.EndTime.Format(time.RFC3339),
+			"end_time":   PointerTimeToStr(params.EndTime),
 			"limit":      PointerIntToStr(params.Limit),
 			"page_token": params.PageToken,
 			"sort_by":    string(params.SortBy),
-			"start_time": params.StartTime.Format(time.RFC3339),
+			"start_time": PointerTimeToStr(params.StartTime),
 		},
 	)
 	if err != nil {
@@ -11350,12 +11349,12 @@ func (c *Client) SystemMetric(
 			"metric_name": string(params.MetricName),
 		},
 		map[string]string{
-			"end_time":   params.EndTime.Format(time.RFC3339),
+			"end_time":   PointerTimeToStr(params.EndTime),
 			"limit":      PointerIntToStr(params.Limit),
 			"order":      string(params.Order),
 			"page_token": params.PageToken,
 			"silo":       string(params.Silo),
-			"start_time": params.StartTime.Format(time.RFC3339),
+			"start_time": PointerTimeToStr(params.StartTime),
 		},
 	)
 	if err != nil {

--- a/oxide/utils.go
+++ b/oxide/utils.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 )
 
 // NewPointer returns a pointer to a given value.
@@ -22,6 +23,16 @@ func PointerIntToStr(i *int) string {
 	}
 
 	return strconv.Itoa(*i)
+}
+
+// PointerTimeToStr converts a *time.Time into an RFC3339 string.
+// If nil, an empty string is returned.
+func PointerTimeToStr(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+
+	return t.Format(time.RFC3339)
 }
 
 // resolveRelative combines a url base with a relative path.


### PR DESCRIPTION
We represent timestamps as `*time.Time`. However, when a nullable timestamp is serialized to query parameters in paths.go, we panic on the nil pointer. This patch adds a helper to wrap time formatting to safely check and omit nil timestamps.

Note: I think we shouldn't represent all timestamps, including non-nullable timestamps, as `*time.Time`, but I'll think about that in another patch.