### PR TITLE
Add nexus errors.

### DIFF
--- a/oxide/errors.go
+++ b/oxide/errors.go
@@ -8,6 +8,79 @@ import (
 	"net/http"
 )
 
+// ErrorCode represents an Oxide API error matched by error_code. Use `errors.Is` to test SDK
+// errors against known error codes.
+//
+// These error codes are derived from the Error enum in omicron:
+// https://github.com/oxidecomputer/omicron/blob/0ef43032/common/src/api/external/error.rs
+//
+// Some upstream variants (e.g. TypeVersionMismatch) are omitted because they serialize
+// to the same error_code as another variant and can't be disambiguated. We also omit the "Not
+// Found" code as described below.
+//
+// TODO: Encode error types in the OpenAPI spec upstream so that we don't have to maintain this
+// mapping in the SDK.
+type ErrorCode struct {
+	code string
+}
+
+func (e *ErrorCode) Error() string {
+	return e.code
+}
+
+var (
+	// ErrObjectNotFound indicates that the requested resource doesn't exist. Note that this doesn't
+	// cover all possible 404 errors from the API. Omicron also uses a generic "Not Found" error
+	// code to represent non-resource not found errors, such as SCIM authz errors and errors from
+	// internal endpoints. The web server also returns a 404 without an error code when the request
+	// path doesn't match any known route. However, these errors are semantically distinct from
+	// ErrObjectNotFound, and represent internal errors that the SDK shouldn't be concerned with.
+	ErrObjectNotFound       error = &ErrorCode{"ObjectNotFound"}
+	ErrObjectAlreadyExists  error = &ErrorCode{"ObjectAlreadyExists"}
+	ErrInvalidRequest       error = &ErrorCode{"InvalidRequest"}
+	ErrInvalidValue         error = &ErrorCode{"InvalidValue"}
+	ErrUnauthenticated      error = &ErrorCode{"Unauthorized"}
+	ErrForbidden            error = &ErrorCode{"Forbidden"}
+	ErrInternalError        error = &ErrorCode{"Internal"}
+	ErrServiceUnavailable   error = &ErrorCode{"ServiceNotAvailable"}
+	ErrInsufficientCapacity error = &ErrorCode{"InsufficientCapacity"}
+	ErrConflict             error = &ErrorCode{"Conflict"}
+	ErrGone                 error = &ErrorCode{"Gone"}
+)
+
+// StatusError represents an Oxide API error matched by HTTP status code. Use `errors.Is` to
+// test SDK errors against known statuses.
+type StatusError struct {
+	status int
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("HTTP %d", e.status)
+}
+
+var (
+	ErrHTTP400 error = &StatusError{400}
+	ErrHTTP401 error = &StatusError{401}
+	ErrHTTP403 error = &StatusError{403}
+	ErrHTTP404 error = &StatusError{404}
+	ErrHTTP409 error = &StatusError{409}
+	ErrHTTP410 error = &StatusError{410}
+	ErrHTTP500 error = &StatusError{500}
+	ErrHTTP503 error = &StatusError{503}
+	ErrHTTP507 error = &StatusError{507}
+)
+
+// Is implements errors.Is. We allow testing against both error code and http status errors.
+func (e *HTTPError) Is(target error) bool {
+	switch t := target.(type) {
+	case *ErrorCode:
+		return e.ErrorResponse != nil && e.ErrorResponse.ErrorCode == t.code
+	case *StatusError:
+		return e.HTTPResponse != nil && e.HTTPResponse.StatusCode == t.status
+	}
+	return false
+}
+
 // HTTPError is an error returned by a failed API call.
 type HTTPError struct {
 	// ErrorResponse is the API's Error response type.

--- a/oxide/errors_test.go
+++ b/oxide/errors_test.go
@@ -2,6 +2,7 @@ package oxide
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -71,7 +72,6 @@ Content-Type: [application/json]
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			println(header)
 			err := HTTPError{
 				ErrorResponse: tt.fields.ErrorResponse,
 				RawBody:       tt.fields.RawBody,
@@ -238,6 +238,106 @@ func Test_NewHTTPError_correct_type(t *testing.T) {
 
 			var apiError *HTTPError
 			assert.Equal(t, errors.As(err, &apiError), true)
+		})
+	}
+}
+
+func TestHTTPError_Is(t *testing.T) {
+	url, _ := url.Parse("http://127.0.0.1:12220/v1/disks/my-disk")
+
+	makeHTTPError := func(errorCode string) error {
+		return &HTTPError{
+			ErrorResponse: &ErrorResponse{
+				ErrorCode: errorCode,
+				Message:   "test message",
+				RequestId: "test-request-id",
+			},
+			HTTPResponse: &http.Response{
+				StatusCode: 400,
+				Header:     make(http.Header),
+				Request:    &http.Request{Method: http.MethodGet, URL: url},
+			},
+		}
+	}
+
+	makeStatusError := func(statusCode int) error {
+		return &HTTPError{
+			HTTPResponse: &http.Response{
+				StatusCode: statusCode,
+				Header:     make(http.Header),
+				Request:    &http.Request{Method: http.MethodGet, URL: url},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		err       error
+		target    error
+		wantMatch bool
+	}{
+		{
+			name:      "matches ObjectNotFound",
+			err:       makeHTTPError("ObjectNotFound"),
+			target:    ErrObjectNotFound,
+			wantMatch: true,
+		},
+		{
+			name:      "matches ObjectAlreadyExists",
+			err:       makeHTTPError("ObjectAlreadyExists"),
+			target:    ErrObjectAlreadyExists,
+			wantMatch: true,
+		},
+		{
+			name:      "does not match different oxide error",
+			err:       makeHTTPError("ObjectNotFound"),
+			target:    ErrObjectAlreadyExists,
+			wantMatch: false,
+		},
+		{
+			name:      "does not match non-oxide error",
+			err:       makeHTTPError("ObjectNotFound"),
+			target:    errors.New("ObjectNotFound"),
+			wantMatch: false,
+		},
+		{
+			name:      "handles fmt.Errorf wrapping",
+			err:       fmt.Errorf("creating disk: %w", makeHTTPError("ObjectNotFound")),
+			target:    ErrObjectNotFound,
+			wantMatch: true,
+		},
+		{
+			name:      "matches status 404",
+			err:       makeStatusError(404),
+			target:    ErrHTTP404,
+			wantMatch: true,
+		},
+		{
+			name:      "matches status 500",
+			err:       makeStatusError(500),
+			target:    ErrHTTP500,
+			wantMatch: true,
+		},
+		{
+			name:      "does not match different status",
+			err:       makeStatusError(404),
+			target:    ErrHTTP500,
+			wantMatch: false,
+		},
+		{
+			name:      "status sentinel matches regardless of error_code",
+			err:       makeHTTPError("ObjectNotFound"),
+			target:    ErrHTTP400,
+			wantMatch: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantMatch {
+				assert.ErrorIs(t, tc.err, tc.target)
+			} else {
+				assert.NotErrorIs(t, tc.err, tc.target)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Today, sdk users have to do a few things to check error codes from the api. The quick option is to check for error code substrings:

```
if strings.Contains(err.Error(), "ObjectNotFound") {
	...
}
```

But this is brittle and doesn't understand the structure of the error. Better is to parse the error into an HTTPError:

```
var httpErr *oxide.HTTPError
if errors.As(err, &httpErr) && httpErr.ErrorResponse.ErrorCode == "ObjectAlreadyExists" {
	...
}
```

But this requires the user to parse the error and reach into its nested fields, then know which string error codes to look for.

This patch adds an OxideError struct, used to represent all known nexus error types. This new error type implements `errors.Is`, so users can write

```
errors.Is(err, oxide.ErrObjectNotFound)
```

without any parsing or implicit knowledge of error codes.